### PR TITLE
Feat/#35

### DIFF
--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/DrawerView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/DrawerView.swift
@@ -4,7 +4,7 @@
 //
 //  Created by zooey on 2022/12/19.
 //
-
+// MARK: -준수 수정함
 import SwiftUI
 import PhotosUI
 

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/DrawerView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/DrawerView.swift
@@ -37,22 +37,25 @@ struct DrawerView: View {
                                 AsyncImage(url: imageUrl) { image in
                                     image
                                         .resizable()
-                                        .scaledToFill()
+                                        .clipShape(Circle())
                                         .frame(width: 110, height: 110)
-                                        .cornerRadius(64)
                                         .overlay(RoundedRectangle(cornerRadius: 64)
                                             .stroke(Color("Pink"), lineWidth: 3))
                                     
                                 } placeholder: {
-                                    
+                                    Image(systemName: "person.circle")
+                                        .resizable()
+                                        .scaledToFit()
+                                        .foregroundColor(Color("Pink"))
+                                        .frame(width: 110, height: 110)
+                                        .aspectRatio(contentMode: .fit)
                                 }
-                            } else{
-                                Image(systemName: "person.fill")
+                            } else {
+                                Image(systemName: "person.circle")
+                                    .resizable()
+                                    .scaledToFit()
                                     .foregroundColor(Color("Pink"))
-                                    .font(.system(size: 64))
-                                    .padding()
-                                    .overlay(RoundedRectangle(cornerRadius: 64)
-                                        .stroke(Color("Pink"), lineWidth: 3))
+                                    .frame(width: 110, height: 110)
                             }
                             
                         }

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreViewModel.swift
@@ -13,6 +13,8 @@ import FirebaseStorage
 
 class FireStoreViewModel: ObservableObject {
     
+    @Published var info: FireStoreModel?
+    
     @Published var users: [FireStoreModel] = []
     @Published var userList: [FriendModel] = []
     @Published var markerList: [MarkerModel] = []
@@ -219,6 +221,37 @@ class FireStoreViewModel: ObservableObject {
            print("imageUpload Fail!")
         }
     }
+    
+    //프로필설정을 마치고 완료버튼을 눌렀을 때 발동
+    func addUserInfo(user: FireStoreModel, downloadUrl: String) {
+        print(#function)
+        database.collection("User")
+            .document(Auth.auth().currentUser?.uid ?? "")
+            .setData(["id": Auth.auth().currentUser?.uid ?? "",
+                      "nickName": user.nickName,
+                      "userPhoto": downloadUrl,
+                      "userEmail": user.userEmail
+                     ])
+    }
+    
+    
+    // MARK: - 회원가입 메서드
+    /// 회원가입시, 유저의 프로필을 파이어스토어 User컬렉션에 등록하는 메서드.
+    func uploadImageToStorage(userImage: UIImage?, user: FireStoreModel) async -> Void {
+        let ref = Storage.storage().reference(withPath: Auth.auth().currentUser?.uid ?? "")
+        guard let userImage, let imageData = userImage.jpegData(compressionQuality: 0.5) else {
+            self.addUserInfo(user: user, downloadUrl: "")
+            return
+        }
+        do{
+            let _ = try await ref.putDataAsync(imageData)
+            let downloadUrl = try await ref.downloadURL()
+            self.addUserInfo(user: user, downloadUrl: downloadUrl.absoluteString)
+        }catch{
+           print("imageUpload Fail!")
+        }
+    }
+    
     // [서랍 doc생성]
     func addCalendar(_ calendar: DayCalendarModel){
         database

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreViewModel.swift
@@ -3,7 +3,7 @@
 //  Gilgaon
 //
 //  Created by kimminho on 2022/12/20.
-
+// MARK: -준수 수정함
 import UIKit
 import Firebase
 import FirebaseFirestore

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
@@ -16,10 +16,10 @@ struct PleaseLoginView: View {
                 if registerModel.currentUser != nil {
                     if registerModel.currentUserProfile == nil {
                             RegisterView()
-                            .deferredRendering(for: 0.5)
+                            .deferredRendering(for: 1.0)
                     } else {
                         HomeView()
-                            .deferredRendering(for: 0.5)
+                            .deferredRendering(for: 1.0)
                     }
                 } else {
                     LoginView()

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
@@ -15,9 +15,11 @@ struct PleaseLoginView: View {
             Group {
                 if registerModel.currentUser != nil {
                     if registerModel.currentUserProfile == nil {
-                        RegisterView()
+                            RegisterView()
+                            .deferredRendering(for: 0.5)
                     } else {
                         HomeView()
+                            .deferredRendering(for: 0.5)
                     }
                 } else {
                     LoginView()
@@ -49,4 +51,44 @@ extension UINavigationController {
     navigationBar.topItem?.backButtonDisplayMode = .minimal
   }
 
+}
+
+// MARK: 지연 시키는 ViewModifier
+private struct DeferredViewModifier: ViewModifier {
+    
+    // MARK: API
+    
+    let threshold: Double
+    
+    // MARK: - ViewModifier
+    
+    func body(content: Content) -> some View {
+        _content(content)
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + threshold) {
+                    self.shouldRender = true
+                }
+            }
+    }
+    
+    // MARK: - Private
+    
+    @ViewBuilder
+    private func _content(_ content: Content) -> some View {
+        if shouldRender {
+            content
+        } else {
+            content
+                .hidden()
+        }
+    }
+    
+    @State
+    private var shouldRender = false
+}
+
+extension View {
+    func deferredRendering(for seconds: Double) -> some View {
+        modifier(DeferredViewModifier(threshold: seconds))
+    }
 }

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
@@ -4,7 +4,7 @@
 //
 //  Created by 전준수 on 2022/12/19.
 //
-
+// MARK: -준수 수정함
 import SwiftUI
 
 struct PleaseLoginView: View {

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/RegisterModel.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/RegisterModel.swift
@@ -4,7 +4,7 @@
 //
 //  Created by kimminho on 2022/12/19.
 //
-
+// MARK: -준수 수정함
 import SwiftUI
 import Firebase
 import FirebaseFirestore

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/RegisterView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/RegisterView.swift
@@ -4,7 +4,7 @@
 //
 //  Created by zooey on 2022/11/29.
 //
-
+// MARK: -준수 수정함
 import SwiftUI
 import Firebase
 import FirebaseStorage

--- a/길가온/Gilgaon/Gilgaon/View/LoginView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/LoginView.swift
@@ -1,3 +1,4 @@
+// MARK: -준수 수정함
 import SwiftUI
 import AuthenticationServices
 


### PR DESCRIPTION
## 제목
서랍장 프로필 사진 미구현된 기능을 추가 및 수정하였습니다.
### 작업사항
- 프로필 사진을 수정할 수 없음
- 사진이 불러와지기 때문에 뷰가 새로 그려지는게 보임

### 적용화면
|<img src="https://user-images.githubusercontent.com/114235515/223121606-4029ee4a-2cc0-4323-b47d-05587fe9d349.gif"></img>|<img src="https://user-images.githubusercontent.com/114235515/223121697-c0be041f-352b-41ae-b165-af19d07aaf35.gif"></img>|
|:-:|:-:|
|`수정 전`|`수정 후`|

```swift
    //프로필설정을 마치고 완료버튼을 눌렀을 때 발동
    func addUserInfo(user: FireStoreModel, downloadUrl: String) {
        print(#function)
        database.collection("User")
            .document(Auth.auth().currentUser?.uid ?? "")
            .setData(["id": Auth.auth().currentUser?.uid ?? "",
                      "nickName": user.nickName,
                      "userPhoto": downloadUrl,
                      "userEmail": user.userEmail
                     ])
    }
    
    
    /// 회원가입시, 유저의 프로필을 파이어스토어 User컬렉션에 등록하는 메서드.
    func uploadImageToStorage(userImage: UIImage?, user: FireStoreModel) async -> Void {
        let ref = Storage.storage().reference(withPath: Auth.auth().currentUser?.uid ?? "")
        guard let userImage, let imageData = userImage.jpegData(compressionQuality: 0.5) else {
            self.addUserInfo(user: user, downloadUrl: "")
            return
        }
        do{
            let _ = try await ref.putDataAsync(imageData)
            let downloadUrl = try await ref.downloadURL()
            self.addUserInfo(user: user, downloadUrl: downloadUrl.absoluteString)
        }catch{
           print("imageUpload Fail!")
        }
    }
```
[FireStoreViewModel] 유저의 프로필 사진을 스토리지에 업로드, 파이어스토어 유저 컬렉션에 업로드하는 함수입니다.

```swift
              AsyncImage(url: imageUrl) { image in
                                                image
                                                    .resizable()
                                                    .clipShape(Circle())
                                                    .frame(width: 110, height: 110)
                                                    .overlay(RoundedRectangle(cornerRadius: 64)
                                                        .stroke(Color("Pink"), lineWidth: 3))
                                                
                                            } placeholder: {
                                                Image(systemName: "person.circle")
                                                    .resizable()
                                                    .scaledToFit()
                                                    .foregroundColor(Color("Pink"))
                                                    .frame(width: 110, height: 110)
                                                    .aspectRatio(contentMode: .fit)
                                            }
```
[DrawerView] 프로필 사진의 플레이스 홀더를 적용하였습니다.


### 특이사항
- 프로필 사진 수정하는 버튼 부분이 사용자가 알아보기 어렵다고 느껴집니다. 의논 후에 별도의 프로필 설정뷰를 만들지 얘기해보면 좋을 것 같습니다.
- 로그인 진행 후에 홈뷰로 넘어가기 전, 프로필 설정뷰가 잠시 뜨는 현상은 지연시키는 ViewModifier를 사용하여 로딩하는 동안 사용자에게 보이지 않게 처리하였습니다. RegisterView과 HomeView 둘다 1초씩 지연하니 보이지 않습니다. 추가로 홈뷰의 설정 버튼도 위에서 아래로 떨어지지 않게 되었습니다.