### PR TITLE
Feat/#45

### DIFF
--- a/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
+++ b/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		63660F4E2937216F00B70272 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63660F4D2937216F00B70272 /* ImagePicker.swift */; };
 		63660F522937573500B70272 /* Customtoggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63660F512937573500B70272 /* Customtoggle.swift */; };
 		6380E7802952C3EE007772C3 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 6380E77F2952C3EE007772C3 /* FirebaseStorage */; };
+		639D9A5429BA115A009D6EAA /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639D9A5329BA115A009D6EAA /* CalendarViewModel.swift */; };
 		63BAEB3A29B748A000D3CD43 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */; };
 		63D2C123293836CD0011BC89 /* DayTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C122293836CD0011BC89 /* DayTask.swift */; };
 		63D2C1282938379C0011BC89 /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C1272938379C0011BC89 /* TaskViewModel.swift */; };
@@ -163,6 +164,7 @@
 		635AE3AC29361A6D008A8452 /* DateTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTask.swift; sourceTree = "<group>"; };
 		63660F4D2937216F00B70272 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		63660F512937573500B70272 /* Customtoggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customtoggle.swift; sourceTree = "<group>"; };
+		639D9A5329BA115A009D6EAA /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
 		63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		63D2C122293836CD0011BC89 /* DayTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTask.swift; sourceTree = "<group>"; };
 		63D2C1272938379C0011BC89 /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
@@ -360,6 +362,7 @@
 				635AE39C2935E9F6008A8452 /* CalendarView.swift */,
 				16CFFE0529363BE900DC0B55 /* CalendarSelectView.swift */,
 				635AE3A229360793008A8452 /* CustomDataPicker.swift */,
+				639D9A5329BA115A009D6EAA /* CalendarViewModel.swift */,
 				63D2C1292938388A0011BC89 /* DayView.swift */,
 				C0B7045A29388F1200245ED7 /* Sakura.json */,
 				16FA82C7293906A6006129D3 /* PopupTest.swift */,
@@ -519,6 +522,7 @@
 				16F69DB729387E030045CD91 /* GilgaonRequestPermissonView.swift in Sources */,
 				16A60C1629B0448600116569 /* SegmentControllView.swift in Sources */,
 				16CFFE0629363BEA00DC0B55 /* CalendarSelectView.swift in Sources */,
+				639D9A5429BA115A009D6EAA /* CalendarViewModel.swift in Sources */,
 				635AE3952935E9DC008A8452 /* LoginView.swift in Sources */,
 				16F69DA7293845E80045CD91 /* LottieView.swift in Sources */,
 				36BB028B29518BD300CF2816 /* WritingView.swift in Sources */,

--- a/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
+++ b/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		1683284329B6DCC800B3EF73 /* FlowerMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1683284229B6DCC800B3EF73 /* FlowerMapViewModel.swift */; };
 		1683284529B6DD0E00B3EF73 /* DrawerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1683284429B6DD0E00B3EF73 /* DrawerDetailView.swift */; };
 		1683284729B6DE6500B3EF73 /* UserMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1683284629B6DE6500B3EF73 /* UserMapView.swift */; };
-		1683284929B6F9DB00B3EF73 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1683284829B6F9DB00B3EF73 /* GoogleService-Info.plist */; };
 		16A60C1429B039C300116569 /* SkeletonUI in Frameworks */ = {isa = PBXBuildFile; productRef = 16A60C1329B039C300116569 /* SkeletonUI */; };
 		16A60C1629B0448600116569 /* SegmentControllView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1529B0448600116569 /* SegmentControllView.swift */; };
 		16A60C1829B044DC00116569 /* FriendSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1729B044DC00116569 /* FriendSettingView.swift */; };
@@ -82,6 +81,7 @@
 		63660F4E2937216F00B70272 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63660F4D2937216F00B70272 /* ImagePicker.swift */; };
 		63660F522937573500B70272 /* Customtoggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63660F512937573500B70272 /* Customtoggle.swift */; };
 		6380E7802952C3EE007772C3 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 6380E77F2952C3EE007772C3 /* FirebaseStorage */; };
+		63BAEB3A29B748A000D3CD43 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */; };
 		63D2C123293836CD0011BC89 /* DayTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C122293836CD0011BC89 /* DayTask.swift */; };
 		63D2C1282938379C0011BC89 /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C1272938379C0011BC89 /* TaskViewModel.swift */; };
 		63D2C12A2938388A0011BC89 /* DayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C1292938388A0011BC89 /* DayView.swift */; };
@@ -107,7 +107,6 @@
 		1683284229B6DCC800B3EF73 /* FlowerMapViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlowerMapViewModel.swift; sourceTree = "<group>"; };
 		1683284429B6DD0E00B3EF73 /* DrawerDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerDetailView.swift; sourceTree = "<group>"; };
 		1683284629B6DE6500B3EF73 /* UserMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserMapView.swift; sourceTree = "<group>"; };
-		1683284829B6F9DB00B3EF73 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../google info/길가온/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		16A60C1529B0448600116569 /* SegmentControllView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentControllView.swift; sourceTree = "<group>"; };
 		16A60C1729B044DC00116569 /* FriendSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSettingView.swift; sourceTree = "<group>"; };
 		16A60C1929B0463400116569 /* FriendRequestCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequestCheckView.swift; sourceTree = "<group>"; };
@@ -164,6 +163,7 @@
 		635AE3AC29361A6D008A8452 /* DateTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTask.swift; sourceTree = "<group>"; };
 		63660F4D2937216F00B70272 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		63660F512937573500B70272 /* Customtoggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customtoggle.swift; sourceTree = "<group>"; };
+		63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		63D2C122293836CD0011BC89 /* DayTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTask.swift; sourceTree = "<group>"; };
 		63D2C1272938379C0011BC89 /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		63D2C1292938388A0011BC89 /* DayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayView.swift; sourceTree = "<group>"; };
@@ -307,7 +307,7 @@
 				1642F0EC2938897E005A54EF /* Font */,
 				C0FA4348293623F4002D4473 /* Gilgaon.entitlements */,
 				6FF334CA2935F1D9007438B1 /* Info.plist */,
-				1683284829B6F9DB00B3EF73 /* GoogleService-Info.plist */,
+				63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */,
 				635AE3842935E932008A8452 /* GilgaonApp.swift */,
 				3663C66D2938631E006880C9 /* MapVIew */,
 				635AE3A729361971008A8452 /* View */,
@@ -472,13 +472,13 @@
 			files = (
 				635AE38C2935E934008A8452 /* Preview Assets.xcassets in Resources */,
 				1642F0FD29388BC6005A54EF /* NotoSerifKR-Medium.otf in Resources */,
+				63BAEB3A29B748A000D3CD43 /* GoogleService-Info.plist in Resources */,
 				1642F0FC29388BC6005A54EF /* NotoSerifKR-SemiBold.otf in Resources */,
 				1642F0FF29388BC6005A54EF /* NotoSerifKR-Bold.otf in Resources */,
 				16CA72952939BDE200D451F0 /* AppIcon.appiconset in Resources */,
 				6FF334C92935F1CD007438B1 /* Config.xcconfig in Resources */,
 				1642F0FA29388BC6005A54EF /* NotoSerifKR-Regular.otf in Resources */,
 				C0B7045B29388F1200245ED7 /* Sakura.json in Resources */,
-				1683284929B6F9DB00B3EF73 /* GoogleService-Info.plist in Resources */,
 				16FA82C6293903BC006129D3 /* InviteFriendLottie.json in Resources */,
 				1642F10029388BC6005A54EF /* NotoSerifKR-ExtraLight.otf in Resources */,
 				1642F0FB29388BC6005A54EF /* NotoSerifKR-Light.otf in Resources */,

--- a/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
+++ b/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
@@ -82,7 +82,6 @@
 		63660F522937573500B70272 /* Customtoggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63660F512937573500B70272 /* Customtoggle.swift */; };
 		6380E7802952C3EE007772C3 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 6380E77F2952C3EE007772C3 /* FirebaseStorage */; };
 		639D9A5429BA115A009D6EAA /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639D9A5329BA115A009D6EAA /* CalendarViewModel.swift */; };
-		63BAEB3A29B748A000D3CD43 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */; };
 		63D2C123293836CD0011BC89 /* DayTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C122293836CD0011BC89 /* DayTask.swift */; };
 		63D2C1282938379C0011BC89 /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C1272938379C0011BC89 /* TaskViewModel.swift */; };
 		63D2C12A2938388A0011BC89 /* DayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D2C1292938388A0011BC89 /* DayView.swift */; };
@@ -165,7 +164,6 @@
 		63660F4D2937216F00B70272 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		63660F512937573500B70272 /* Customtoggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customtoggle.swift; sourceTree = "<group>"; };
 		639D9A5329BA115A009D6EAA /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
-		63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		63D2C122293836CD0011BC89 /* DayTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTask.swift; sourceTree = "<group>"; };
 		63D2C1272938379C0011BC89 /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		63D2C1292938388A0011BC89 /* DayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayView.swift; sourceTree = "<group>"; };
@@ -309,7 +307,6 @@
 				1642F0EC2938897E005A54EF /* Font */,
 				C0FA4348293623F4002D4473 /* Gilgaon.entitlements */,
 				6FF334CA2935F1D9007438B1 /* Info.plist */,
-				63BAEB3929B748A000D3CD43 /* GoogleService-Info.plist */,
 				635AE3842935E932008A8452 /* GilgaonApp.swift */,
 				3663C66D2938631E006880C9 /* MapVIew */,
 				635AE3A729361971008A8452 /* View */,
@@ -475,7 +472,6 @@
 			files = (
 				635AE38C2935E934008A8452 /* Preview Assets.xcassets in Resources */,
 				1642F0FD29388BC6005A54EF /* NotoSerifKR-Medium.otf in Resources */,
-				63BAEB3A29B748A000D3CD43 /* GoogleService-Info.plist in Resources */,
 				1642F0FC29388BC6005A54EF /* NotoSerifKR-SemiBold.otf in Resources */,
 				1642F0FF29388BC6005A54EF /* NotoSerifKR-Bold.otf in Resources */,
 				16CA72952939BDE200D451F0 /* AppIcon.appiconset in Resources */,

--- a/길가온/Gilgaon/Gilgaon/GilgaonApp.swift
+++ b/길가온/Gilgaon/Gilgaon/GilgaonApp.swift
@@ -31,7 +31,7 @@ struct GilgaonApp: App {
                 .environmentObject(RegisterModel())
                 .environmentObject(LocationsViewModel())
                 .environmentObject(SearchViewModel())
-                .environmentObject(CalendarViewModel())
+//                .environmentObject(CalendarViewModel())
                 .environmentObject(FireStoreViewModel())
         }
     }

--- a/길가온/Gilgaon/Gilgaon/Model/DateTask.swift
+++ b/길가온/Gilgaon/Gilgaon/Model/DateTask.swift
@@ -1,53 +1,54 @@
+////
+////  DateTask.swift
+////  Gilgaon
+////
+////  Created by zooey on 2022/11/29.
+////
 //
-//  DateTask.swift
-//  Gilgaon
+//import SwiftUI
 //
-//  Created by zooey on 2022/11/29.
 //
-
-import SwiftUI
-
-struct DateTask: Identifiable {
-    var id = UUID().uuidString
-    var title: String
-    var taskDate: Date
-    var realDate: [String]
-    var time: Date = Date()
-}
-
-class CalendarViewModel: ObservableObject,Identifiable {
-    @Published var tasks: [DateTask]
-    init() {
-        let tasks = CalendarModel.selectDayInfo
-        self.tasks = tasks
-    }
-}
-
-class CalendarModel {
-    static var selectDayInfo: [DateTask] = []
-}
-
-func getSampleDate(offset: Int) -> Date {
-    
-    let calender = Calendar.current
-    let date = calender.date(byAdding: .day, value: offset, to: Date())
-    return date ?? Date()
-    
-}
-
-var tasks: [DateTask] = []
-
-func DateType2String() -> [String]{
-    let current = Date()
-    
-    let formatter = DateFormatter()
-    //한국 시간으로 표시
-    formatter.locale = Locale(identifier: "ko_kr")
-    formatter.timeZone = TimeZone(abbreviation: "KST")
-    //형태 변환
-    formatter.dateFormat = "yyyy MM dd"
-    
-    let date = formatter.string(from: current)
-//    return date
-    return date.components(separatedBy: " ")
-}
+//struct DateTask: Identifiable {
+//    var id = UUID().uuidString
+//    var title: String
+//    var taskDate: Date
+//    var realDate: [String]
+//    var time: Date = Date()
+//}
+//
+//class CalendarViewModel: ObservableObject,Identifiable {
+//    @Published var tasks: [DateTask]
+//    init() {
+//        let tasks = CalendarModel.selectDayInfo
+//        self.tasks = tasks
+//    }
+//}
+//
+//class CalendarModel {
+//    static var selectDayInfo: [DateTask] = []
+//}
+//
+//func getSampleDate(offset: Int) -> Date {
+//
+//    let calender = Calendar.current
+//    let date = calender.date(byAdding: .day, value: offset, to: Date())
+//    return date ?? Date()
+//
+//}
+//
+//var tasks: [DateTask] = []
+//
+//func DateType2String() -> [String]{
+//    let current = Date()
+//
+//    let formatter = DateFormatter()
+//    //한국 시간으로 표시
+//    formatter.locale = Locale(identifier: "ko_kr")
+//    formatter.timeZone = TimeZone(abbreviation: "KST")
+//    //형태 변환
+//    formatter.dateFormat = "yyyy MM dd"
+//
+//    let date = formatter.string(from: current)
+////    return date
+//    return date.components(separatedBy: " ")
+//}

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreModel.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreModel.swift
@@ -40,7 +40,7 @@ struct DayCalendarModel: Identifiable,Hashable{
 }
 
 // [마커 Data]
-struct MarkerModel: Identifiable, Equatable {
+struct MarkerModel: Identifiable, Equatable, Hashable {
     var id: String
     var title: String
     var photo: String

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct CalendarSelectView: View {
     
     @ObservedObject var calendarViewModel: CalendarViewModel
-//    @State var getStringValue: String
     
     var body: some View {
         
@@ -54,20 +53,14 @@ struct CalendarSelectView: View {
                 }
                 .padding()
             }
-//            .onAppear{
-//                Task{
-//                    calendarViewModel.mapID = getStringValue
-//                    await calendarViewModel.fetchMap()
-//                }
-//            }
         }
     }
 }
 
-//struct CalendarSelectView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        CalendarSelectView(flowerMapViewModel: FlowerMapViewModel(), getStringValue: "")
-//    }
-//}
+struct CalendarSelectView_Previews: PreviewProvider {
+    static var previews: some View {
+        CalendarSelectView(calendarViewModel: CalendarViewModel())
+    }
+}
 
 

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -7,24 +7,10 @@
 
 import SwiftUI
 
-struct Test: Identifiable, Hashable {
-    var id = UUID()
-    var date: String
-    var location: String
-}
-
 struct CalendarSelectView: View {
     
-    var array: [Test] = [
-        Test(date: "11:32", location: "명동"),
-        Test(date: "12:14", location: "명동칼국수"),
-        Test(date: "13:27", location: "스타벅스 명동점"),
-        Test(date: "17:58", location: "명동 돈까스"),
-        Test(date: "18:46", location: "명동 와인바"),
-    ]
-    
-    @ObservedObject var flowerMapViewModel: FlowerMapViewModel
-    @State var getStringValue: String
+    @ObservedObject var calendarViewModel: CalendarViewModel
+//    @State var getStringValue: String
     
     var body: some View {
         
@@ -33,9 +19,8 @@ struct CalendarSelectView: View {
                 .ignoresSafeArea()
             
             ScrollView(.horizontal, showsIndicators: false) {
-                
                 HStack {
-                    ForEach(flowerMapViewModel.locations, id: \.self) { item in
+                    ForEach(calendarViewModel.mapDataList, id: \.self) { item in
                         VStack {
                             HStack {
                                 Rectangle()
@@ -69,13 +54,20 @@ struct CalendarSelectView: View {
                 }
                 .padding()
             }
+//            .onAppear{
+//                Task{
+//                    calendarViewModel.mapID = getStringValue
+//                    await calendarViewModel.fetchMap()
+//                }
+//            }
         }
     }
 }
-struct CalendarSelectView_Previews: PreviewProvider {
-    static var previews: some View {
-        CalendarSelectView(flowerMapViewModel: FlowerMapViewModel(), getStringValue: "")
-    }
-}
+
+//struct CalendarSelectView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CalendarSelectView(flowerMapViewModel: FlowerMapViewModel(), getStringValue: "")
+//    }
+//}
 
 

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -7,26 +7,75 @@
 
 import SwiftUI
 
+struct Test: Identifiable, Hashable {
+    var id = UUID()
+    var date: String
+    var location: String
+}
+
 struct CalendarSelectView: View {
+    
+    var array: [Test] = [
+        Test(date: "11:32", location: "명동"),
+        Test(date: "12:14", location: "명동칼국수"),
+        Test(date: "13:27", location: "스타벅스 명동점"),
+        Test(date: "17:58", location: "명동 돈까스"),
+        Test(date: "18:46", location: "명동 와인바"),
+    ]
+    
+    @ObservedObject var flowerMapViewModel: FlowerMapViewModel
+    @State var getStringValue: String
     
     var body: some View {
         
         ZStack {
-            
             Color("White")
                 .ignoresSafeArea()
             
-            VStack {
+            ScrollView(.horizontal, showsIndicators: false) {
                 
-                
+                HStack {
+                    ForEach(flowerMapViewModel.locations, id: \.self) { item in
+                        VStack {
+                            HStack {
+                                Rectangle()
+                                    .frame(height: 1)
+                                
+                                Circle()
+                                    .frame(width: 15, height: 15)
+                                    .background(
+                                        Circle()
+                                            .stroke(lineWidth: 1)
+                                            .padding(-3)
+                                    )
+                                
+                                Rectangle()
+                                    .frame(height: 1)
+                            }
+                            
+                            VStack {
+                                Text(item.createdDate)
+                                Text(item.locationName)
+                            }
+                            .padding()
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color("Pink"), lineWidth: 1.5)
+                            }
+                        }
+                    }
+                    .foregroundColor(Color("DarkGray"))
+                    .font(.custom("NotoSerifKR-Regular", size: 18))
+                }
+                .padding()
             }
-            .foregroundColor(Color("DarkGray"))
         }
     }
 }
-
 struct CalendarSelectView_Previews: PreviewProvider {
     static var previews: some View {
-        CalendarSelectView()
+        CalendarSelectView(flowerMapViewModel: FlowerMapViewModel(), getStringValue: "")
     }
 }
+
+

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -2,32 +2,12 @@
 //  CalendarSelectView.swift
 //  Gilgaon
 //
-//  Created by kimminho on 2022/11/29.
+//  Created by zooey on 2023/03/07.
 //
 
 import SwiftUI
 
-
-//MARK: - 안쓰는뷰
 struct CalendarSelectView: View {
-    @State private var friendArray: [String] = []
-    @State private var emoji: [String] = ["😆","😏","🥹"]
-    @State private var showInSheet: Bool = false
-    
-    
-    func friendCircle() -> some View {
-        ZStack {
-            Circle()
-                .foregroundColor(.gray)
-                .frame(width: 100,height: 100)
-            Image(systemName: "plus")
-                .overlay(Circle().stroke(.black,lineWidth: 0.5))
-                .offset(x:33,y:30)
-        }
-
-            
-    }
-    
     
     var body: some View {
         
@@ -37,33 +17,10 @@ struct CalendarSelectView: View {
                 .ignoresSafeArea()
             
             VStack {
-                Text("00월 00 일의 일정을 시작합니다")
-                    .foregroundColor(Color("DarkGray"))
-                HStack {
-                    Text("함께하는 친구")
-                        .foregroundColor(Color("DarkGray"))
-                    Button {
-                        
-                        showInSheet.toggle()
-                    } label: {
-                        Image(systemName: "plus")
-                            .foregroundColor(Color("Red"))
-                    }
-                    .sheet(isPresented: $showInSheet) {
-                        InviteFriendView()
-                            .presentationDetents([.medium,.large]) //미디엄까지 modal 올라옴
-                    }
-                }
                 
-                friendCircle()
                 
-                HStack {
-                    Image(systemName: "cloud")
-                    Image(systemName: "cloud")
-                    Image(systemName: "cloud")
-                }
-                .foregroundColor(Color("DarkGray"))
             }
+            .foregroundColor(Color("DarkGray"))
         }
     }
 }

--- a/길가온/Gilgaon/Gilgaon/View/CalendarView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarView.swift
@@ -12,19 +12,17 @@ struct CalendarView: View {
     @State var currentDate = Date()
     @State var calID: [String] = []
     @State var isTapped: Bool = true
-
+    
     var body: some View {
-        
         
         ZStack {
             Color("White")
                 .ignoresSafeArea()
-
-                VStack(spacing: 20) {
-                    CustomDataPicker(currentDate: currentDate, calID: $calID)
-
-                }
-                .padding(.vertical)
+            
+            VStack(spacing: 20) {
+                CustomDataPicker(currentDate: currentDate, calID: $calID)
+            }
+            .padding(.vertical)
         }
     }
 }

--- a/길가온/Gilgaon/Gilgaon/View/CalendarView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct CalendarView: View {
     
-    @State var currentDate = Date()
     @State var calID: [String] = []
     @State var isTapped: Bool = true
     
@@ -20,7 +19,7 @@ struct CalendarView: View {
                 .ignoresSafeArea()
             
             VStack(spacing: 20) {
-                CustomDataPicker(currentDate: currentDate, calID: $calID)
+                CustomDataPicker(calID: $calID)
             }
             .padding(.vertical)
         }

--- a/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  CalendarViewModel.swift
+//  Gilgaon
+//
+//  Created by zooey on 2023/03/09.
+//
+
+import Foundation
+
+final class CalendarViewModel: ObservableObject {
+    
+    let fireStore = FireStoreViewModel()
+    
+    @Published var drawerID: String = ""
+    @Published var mapID: String = ""
+    @Published var drawerDataList: [DayCalendarModel] = []
+    @Published var mapDataList: [MarkerModel] = []
+    
+    func fetchDrawer() {
+        fireStore.fetchDayCalendar()
+        self.drawerDataList = fireStore.calendarList
+    }
+    
+    @MainActor
+    func fetchMap() async {
+        self.mapDataList = await fireStore.fetchMarkers(inputID: self.mapID)
+    }
+}
+

--- a/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
@@ -23,7 +23,7 @@ final class CalendarViewModel: ObservableObject {
     
     @MainActor
     func fetchMap() async {
-        self.mapDataList = await fireStore.fetchMarkers(inputID: self.mapID)
+        self.mapDataList = await fireStore.fetchMarkers(inputID: self.mapID).sorted(by: { $1.createdDate > $0.createdDate})
     }
 }
 

--- a/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct CustomDataPicker: View {
-    @EnvironmentObject var fireStoreModel: FireStoreViewModel
+    @StateObject var fireStoreModel: FireStoreViewModel = FireStoreViewModel()
     
     @State var currentDate = Date()
     @Binding var calID: [String]
     @State var currentMonth: Int = 0
     
     let days: [String] = ["일", "월", "화", "수", "목", "금", "토"]
+    
+    @StateObject var flowerMapViewModel = FlowerMapViewModel()
     
     var body: some View {
         
@@ -96,7 +98,6 @@ struct CustomDataPicker: View {
                                         )
                                         .onTapGesture {
                                             currentDate = value.date
-                                            let createdAt = value.date.timeIntervalSince1970
                                         }
                                 }
                             }
@@ -111,7 +112,6 @@ struct CustomDataPicker: View {
                         // 달력 밑에 데이터 보여주고 싶으면 여기에
                         
                     }
-                    .padding()
                 }
                 .onChange(of: currentMonth) { newValue in
                     currentDate = getCurrentMonth()

--- a/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
@@ -17,6 +17,7 @@ struct CustomDataPicker: View {
     let days: [String] = ["일", "월", "화", "수", "목", "금", "토"]
     
     var body: some View {
+        
         ScrollView{
             ScrollViewReader { value in
                 VStack(spacing: 35) {
@@ -95,15 +96,12 @@ struct CustomDataPicker: View {
                                         )
                                         .onTapGesture {
                                             currentDate = value.date
-//                                            print(value.date)
                                             let createdAt = value.date.timeIntervalSince1970
                                         }
                                 }
                             }
                             .onAppear {
-                                Task {
-                                    try! await fireStoreModel.fetchDayCalendar()
-                                }
+                                fireStoreModel.fetchDayCalendar()
                             }
                         }
                         .offset(y: 20)
@@ -111,14 +109,30 @@ struct CustomDataPicker: View {
                     
                     VStack(spacing: 15) {
                         // 달력 밑에 데이터 보여주고 싶으면 여기에
+                        
                     }
                     .padding()
                 }
                 .onChange(of: currentMonth) { newValue in
                     currentDate = getCurrentMonth()
                 }
-            }//ScrollView
+            }
+            
         }
+        .gesture(
+            DragGesture()
+                .onEnded { gesture in
+                    if gesture.translation.width < 0 {
+                        withAnimation(.spring()) {
+                            currentMonth += 1
+                        }
+                    } else {
+                        withAnimation(.spring()) {
+                            currentMonth -= 1
+                        }
+                    }
+                }
+        )
     }
     
     @ViewBuilder
@@ -154,7 +168,6 @@ struct CustomDataPicker: View {
         .padding(.vertical, 9)
         .frame(height: 60, alignment: .top)
     }
-    
     
     func isSameDay(date1: Date, date2: Date) -> Bool {
         

--- a/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
@@ -15,7 +15,6 @@ struct CustomDataPicker: View {
     @State var currentDate: Date = Date()
     @Binding var calID: [String]
     @State var currentMonth: Int = 0
-//    @State var getStringValue: String = ""
     
     let days: [String] = ["일", "월", "화", "수", "목", "금", "토"]
         

--- a/길가온/Gilgaon/Gilgaon/View/DayView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/DayView.swift
@@ -1,229 +1,229 @@
+////
+////  DayView.swift
+////  Gilgaon
+////
+////  Created by zooey on 2022/12/01.
+////
 //
-//  DayView.swift
-//  Gilgaon
-//
-//  Created by zooey on 2022/12/01.
-//
-
 import SwiftUI
-
-struct DayView: View {
-    
-    @StateObject var taskModel: TaskViewModel = TaskViewModel()
-    @EnvironmentObject private var cvm: CalendarViewModel
-    @Binding var calID: [String]
-    @Namespace var animation
-    
-    var body: some View {
-        
-        ZStack {
-            
-            Color("White")
-                .ignoresSafeArea()
-            
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(spacing: 15, pinnedViews: [.sectionHeaders]) {
-                    
-                    Section {
-                        
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            
-                            HStack(spacing: 10) {
-                                
-                                ForEach(taskModel.currentWeek, id: \.self) { day in
-                                    
-                                    VStack(spacing: 10) {
-                                        
-                                        Text(taskModel.extractDate(date: day, format: "dd"))
-                                            .font(.custom("NotoSerifKR-SemiBold", size: 17))
-                                        
-                                        
-                                        Text(taskModel.extractDate(date: day, format: "EEE"))
-                                            .font(.custom("NotoSerifKR-SemiBold", size: 17))
-                                        
-                                        Circle()
-                                            .fill(Color("White"))
-                                            .frame(width: 8, height: 8)
-                                            .opacity(taskModel.isToday(date: day) ? 1 : 0)
-                                            
-                                        
-                                    }
-                                    .foregroundStyle(taskModel.isToday(date: day) ? .primary : .secondary)
-                                    .foregroundColor(taskModel.isToday(date: day) ? Color("White") : Color("DarkGray"))
-                                    .frame(width: 45, height: 90)
-                                    .background(
-                                    
-                                        ZStack {
-                                            if taskModel.isToday(date: day) {
-                                                
-                                                Capsule()
-                                                    .fill(Color("Pink"))
-                                                    .matchedGeometryEffect(id: "CURRENTDAY", in: animation)
-                                            }
-                                        }
-                                    )
-                                    .contentShape(Capsule())
-                                    .onTapGesture {
-                                        withAnimation {
-                                            taskModel.currentDay = day
-                                        }
-                                    }
-                                }
-                            }
-                            .padding(.horizontal)
-                        }
-                        
-                        tasksView()
-                        
-                    } header: {
-                        headerView()
-                    }
-                }
-            }
-            .ignoresSafeArea(.container, edges: .top)
-        }
-    }
-    
-    func tasksView() -> some View {
-        LazyVStack(spacing: 18) {
-            if let tasks = cvm.tasks {
-                if tasks.isEmpty {
-                    Text("남겨진 꽃갈피가 없습니다.")
-                        .font(.custom("NotoSerifKR-Light", size: 15))
-                        .foregroundColor(Color("DarkGray"))
-                        .offset(y: 100)
-                } else {
-                    ForEach(cvm.tasks.filter {$0.realDate.contains(calID)}) { task in
-                        NavigationLink(destination: EmptyView()) {
-                            taskCardView(task: task)
-                                .font(.custom("NotoSerifKR-SemiBold", size: 15))
-                        }
-                    }
-                }
-            } else {
-                ProgressView()
-                    .offset(y: 100)
-            }
-        }
-        .padding()
-        .padding(.top)
-        .onChange(of: taskModel.currentDay) { newValue in
-            taskModel.filterTodayTasks()
-        }
-    }
-    
-    func taskCardView(task: DateTask) -> some View {
-        
-        HStack(alignment: .top, spacing: 30) {
-            VStack(spacing: 10) {
-                Circle()
-                    .fill(Color("Pink"))
-                    .frame(width: 15, height: 15)
-                    .background(
-                        Circle()
-                            .stroke(Color("Pink"), lineWidth: 1)
-                            .padding(-3)
-                    )
-                
-                Rectangle()
-                    .fill(Color("Pink"))
-                    .opacity(0.4)
-                    .frame(width: 3)
-            }
-            
-            VStack {
-                
-                HStack(alignment: .top, spacing: 10) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(task.title)
-                            .font(.custom("NotoSerifKR-Bold", size: 19))
-                        
-                        Text("\(task.time)")
-                            .font(.custom("NotoSerifKR-Regular", size: 16))
-                            .foregroundStyle(.secondary)
-                        
-                    }
-                    .hLeading()
-                    
-                    Text(task.taskDate.formatted(date: .omitted, time: .shortened))
-                }
-                
-                HStack(spacing: 0) {
-                    HStack(spacing: -10) {
-                        ForEach(["p2", "p3", "p4"], id: \.self) { user in
-                            
-                            Image(user)
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 45, height: 45)
-                                .clipShape(Circle())
-                                .background(
-                                Circle()
-                                    .stroke(Color("DarkGray"), lineWidth: 2)
-                                )
-                            
-                        }
-                    }
-                    .hLeading()
-                }
-                .padding(.top)
-                
-            }
-            .foregroundColor(Color("DarkGray"))
-            .padding()
-            .hLeading()
-            .background(
-            Color("Pink")
-                .cornerRadius(25)
-                .opacity(0.4)
-            )
-        }
-        .hLeading()
-    }
- 
-    func headerView() -> some View {
-        
-        HStack(spacing: 10) {
-            
-            VStack(alignment: .leading, spacing: 10) {
-                
-                ZStack(alignment: .leading) {
-                    
-                    MyPath6()
-                        .stroke(Color("Pink"))
-                    
-                    Text("꽃   갈   피")
-                        .font(.custom("NotoSerifKR-Bold", size: 30))
-                        .foregroundColor(Color("DarkGray"))
-                        .offset(x: 50, y: 4)
-                }
-                .padding(.top, 20)
-            }
-
-            
-            Button {
-                
-            } label: {
-                Image("p1")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 45, height: 45)
-                    .clipShape(Circle())
-            }
-        }
-        .padding()
-        .padding(.top, getSafeAtrea().top)
-    }
-    
-}
-
-struct DayView_Previews: PreviewProvider {
-    static var previews: some View {
-        DayView(calID: .constant([]))
-    }
-}
-
-
+//
+//struct DayView: View {
+//    
+//    @StateObject var taskModel: TaskViewModel = TaskViewModel()
+//    @EnvironmentObject private var cvm: CalendarViewModel
+//    @Binding var calID: [String]
+//    @Namespace var animation
+//    
+//    var body: some View {
+//        
+//        ZStack {
+//            
+//            Color("White")
+//                .ignoresSafeArea()
+//            
+//            ScrollView(.vertical, showsIndicators: false) {
+//                LazyVStack(spacing: 15, pinnedViews: [.sectionHeaders]) {
+//                    
+//                    Section {
+//                        
+//                        ScrollView(.horizontal, showsIndicators: false) {
+//                            
+//                            HStack(spacing: 10) {
+//                                
+//                                ForEach(taskModel.currentWeek, id: \.self) { day in
+//                                    
+//                                    VStack(spacing: 10) {
+//                                        
+//                                        Text(taskModel.extractDate(date: day, format: "dd"))
+//                                            .font(.custom("NotoSerifKR-SemiBold", size: 17))
+//                                        
+//                                        
+//                                        Text(taskModel.extractDate(date: day, format: "EEE"))
+//                                            .font(.custom("NotoSerifKR-SemiBold", size: 17))
+//                                        
+//                                        Circle()
+//                                            .fill(Color("White"))
+//                                            .frame(width: 8, height: 8)
+//                                            .opacity(taskModel.isToday(date: day) ? 1 : 0)
+//                                            
+//                                        
+//                                    }
+//                                    .foregroundStyle(taskModel.isToday(date: day) ? .primary : .secondary)
+//                                    .foregroundColor(taskModel.isToday(date: day) ? Color("White") : Color("DarkGray"))
+//                                    .frame(width: 45, height: 90)
+//                                    .background(
+//                                    
+//                                        ZStack {
+//                                            if taskModel.isToday(date: day) {
+//                                                
+//                                                Capsule()
+//                                                    .fill(Color("Pink"))
+//                                                    .matchedGeometryEffect(id: "CURRENTDAY", in: animation)
+//                                            }
+//                                        }
+//                                    )
+//                                    .contentShape(Capsule())
+//                                    .onTapGesture {
+//                                        withAnimation {
+//                                            taskModel.currentDay = day
+//                                        }
+//                                    }
+//                                }
+//                            }
+//                            .padding(.horizontal)
+//                        }
+//                        
+//                        tasksView()
+//                        
+//                    } header: {
+//                        headerView()
+//                    }
+//                }
+//            }
+//            .ignoresSafeArea(.container, edges: .top)
+//        }
+//    }
+//    
+//    func tasksView() -> some View {
+//        LazyVStack(spacing: 18) {
+//            if let tasks = cvm.tasks {
+//                if tasks.isEmpty {
+//                    Text("남겨진 꽃갈피가 없습니다.")
+//                        .font(.custom("NotoSerifKR-Light", size: 15))
+//                        .foregroundColor(Color("DarkGray"))
+//                        .offset(y: 100)
+//                } else {
+//                    ForEach(cvm.tasks.filter {$0.realDate.contains(calID)}) { task in
+//                        NavigationLink(destination: EmptyView()) {
+//                            taskCardView(task: task)
+//                                .font(.custom("NotoSerifKR-SemiBold", size: 15))
+//                        }
+//                    }
+//                }
+//            } else {
+//                ProgressView()
+//                    .offset(y: 100)
+//            }
+//        }
+//        .padding()
+//        .padding(.top)
+//        .onChange(of: taskModel.currentDay) { newValue in
+//            taskModel.filterTodayTasks()
+//        }
+//    }
+//    
+//    func taskCardView(task: DateTask) -> some View {
+//        
+//        HStack(alignment: .top, spacing: 30) {
+//            VStack(spacing: 10) {
+//                Circle()
+//                    .fill(Color("Pink"))
+//                    .frame(width: 15, height: 15)
+//                    .background(
+//                        Circle()
+//                            .stroke(Color("Pink"), lineWidth: 1)
+//                            .padding(-3)
+//                    )
+//                
+//                Rectangle()
+//                    .fill(Color("Pink"))
+//                    .opacity(0.4)
+//                    .frame(width: 3)
+//            }
+//            
+//            VStack {
+//                
+//                HStack(alignment: .top, spacing: 10) {
+//                    VStack(alignment: .leading, spacing: 12) {
+//                        Text(task.title)
+//                            .font(.custom("NotoSerifKR-Bold", size: 19))
+//                        
+//                        Text("\(task.time)")
+//                            .font(.custom("NotoSerifKR-Regular", size: 16))
+//                            .foregroundStyle(.secondary)
+//                        
+//                    }
+//                    .hLeading()
+//                    
+//                    Text(task.taskDate.formatted(date: .omitted, time: .shortened))
+//                }
+//                
+//                HStack(spacing: 0) {
+//                    HStack(spacing: -10) {
+//                        ForEach(["p2", "p3", "p4"], id: \.self) { user in
+//                            
+//                            Image(user)
+//                                .resizable()
+//                                .aspectRatio(contentMode: .fill)
+//                                .frame(width: 45, height: 45)
+//                                .clipShape(Circle())
+//                                .background(
+//                                Circle()
+//                                    .stroke(Color("DarkGray"), lineWidth: 2)
+//                                )
+//                            
+//                        }
+//                    }
+//                    .hLeading()
+//                }
+//                .padding(.top)
+//                
+//            }
+//            .foregroundColor(Color("DarkGray"))
+//            .padding()
+//            .hLeading()
+//            .background(
+//            Color("Pink")
+//                .cornerRadius(25)
+//                .opacity(0.4)
+//            )
+//        }
+//        .hLeading()
+//    }
+// 
+//    func headerView() -> some View {
+//        
+//        HStack(spacing: 10) {
+//            
+//            VStack(alignment: .leading, spacing: 10) {
+//                
+//                ZStack(alignment: .leading) {
+//                    
+//                    MyPath6()
+//                        .stroke(Color("Pink"))
+//                    
+//                    Text("꽃   갈   피")
+//                        .font(.custom("NotoSerifKR-Bold", size: 30))
+//                        .foregroundColor(Color("DarkGray"))
+//                        .offset(x: 50, y: 4)
+//                }
+//                .padding(.top, 20)
+//            }
+//
+//            
+//            Button {
+//                
+//            } label: {
+//                Image("p1")
+//                    .resizable()
+//                    .aspectRatio(contentMode: .fill)
+//                    .frame(width: 45, height: 45)
+//                    .clipShape(Circle())
+//            }
+//        }
+//        .padding()
+//        .padding(.top, getSafeAtrea().top)
+//    }
+//    
+//}
+//
+//struct DayView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        DayView(calID: .constant([]))
+//    }
+//}
+//
+//
 extension View {
     
     func hLeading() -> some View {
@@ -253,39 +253,39 @@ extension View {
         return safeArea
     }
 }
-
-
-struct MyPath6: Shape {
-    
-    func path(in rect: CGRect) -> Path {
-        
-        var path = Path()
-        
-        path.move(to: CGPoint(x: 20, y: 0))
-        path.addLine(to: CGPoint(x: 210, y: 0))
-        
-        path.move(to: CGPoint(x: 20, y: 3))
-        path.addLine(to: CGPoint(x: 210, y: 3))
-        
-        path.move(to: CGPoint(x: 20, y: 50))
-        path.addLine(to: CGPoint(x: 210, y: 50))
-        
-        path.move(to: CGPoint(x: 20, y: 53))
-        path.addLine(to: CGPoint(x: 210, y: 53))
-        
-        path.move(to: CGPoint(x: 40, y: 3))
-        path.addLine(to: CGPoint(x: 40, y: 50))
-        
-        path.move(to: CGPoint(x: 90, y: 3))
-        path.addLine(to: CGPoint(x: 90, y: 50))
-        
-        path.move(to: CGPoint(x: 140, y: 3))
-        path.addLine(to: CGPoint(x: 140, y: 50))
-        
-        path.move(to: CGPoint(x: 190, y: 3))
-        path.addLine(to: CGPoint(x: 190, y: 50))
-       
-        
-        return path
-    }
-}
+//
+//
+//struct MyPath6: Shape {
+//    
+//    func path(in rect: CGRect) -> Path {
+//        
+//        var path = Path()
+//        
+//        path.move(to: CGPoint(x: 20, y: 0))
+//        path.addLine(to: CGPoint(x: 210, y: 0))
+//        
+//        path.move(to: CGPoint(x: 20, y: 3))
+//        path.addLine(to: CGPoint(x: 210, y: 3))
+//        
+//        path.move(to: CGPoint(x: 20, y: 50))
+//        path.addLine(to: CGPoint(x: 210, y: 50))
+//        
+//        path.move(to: CGPoint(x: 20, y: 53))
+//        path.addLine(to: CGPoint(x: 210, y: 53))
+//        
+//        path.move(to: CGPoint(x: 40, y: 3))
+//        path.addLine(to: CGPoint(x: 40, y: 50))
+//        
+//        path.move(to: CGPoint(x: 90, y: 3))
+//        path.addLine(to: CGPoint(x: 90, y: 50))
+//        
+//        path.move(to: CGPoint(x: 140, y: 3))
+//        path.addLine(to: CGPoint(x: 140, y: 50))
+//        
+//        path.move(to: CGPoint(x: 190, y: 3))
+//        path.addLine(to: CGPoint(x: 190, y: 50))
+//       
+//        
+//        return path
+//    }
+//}


### PR DESCRIPTION
## 달력뷰 세부뷰 추가
- 달력뷰 밑에 부분에 세부뷰 추가
- 남겨진 꽃갈피가 있는 경우 꽃갈피의 기본적인 내용, 시간 등을 보여줌
- 꽃갈피가 없는 경우 남겨진 꽃갈피가 없다고 알려줌

### 작업사항
-  달력뷰 밑에 시간, 장소별로 내가 남긴 꽃갈피 보여주기
- 달력 슬라이드로 넘기는 기능 추가

### 적용화면
```swift
.gesture(
       DragGesture()
            .onEnded { gesture in
                 if gesture.translation.width < 0 {
                    withAnimation(.spring()) {
                      currentMonth += 1
                        }
                    } else {
                        withAnimation(.spring()) {
                            currentMonth -= 1
                        }
                    }
                }
        )
```
- 제스처로 달력을 넘기는 것을 만들때 처음에는 UIKit으로 커스텀 제스처를 만들어서 사용했지만 ZStack 가장 위에서만 동작해 달력의 다른 기능들을 사용할 수 없었습니다. 그래서 .gesture() 안에 DragGesture()를 사용해 넘겨주는 방법을 선택했는데 이 또한 무한대로 숫자가 넘어가는 현상이 발생했습니다. 프린트를 찍어서 값이 어떻게 변화하는지 확인해봤더니 오른쪽 왼쪽으로 움직일때 값이 양수와 음수 인것을 확인했습니다. 그 값을 이용해 값이 한칸씩 넘어가도록 수정했습니다.

```swift
// 1. 처음에 id값과 배열모두 초기화해줘서 제대로 내용이 나오지 않음
.onAppear {
       Task {
               calendarViewModel.mapID = dateTask.id
                await calendarViewModel.fetchMap()
                 calendarViewModel.mapID = ""
                calendarViewModel.mapDataList = []
                    }
               }
 .onChange(of: dateTask.id) { newValue in
                  Task {            
                       calendarViewModel.mapID = newValue
                       await calendarViewModel.fetchMap()    
                        }
                     }

// 2. id값과 배열을 모두 onChange에서 초기화해줘서 한박자 느리게 데이터가 나타남
.onAppear {
       Task {
               calendarViewModel.mapID = dateTask.id
                await calendarViewModel.fetchMap()
                    }
               }
 .onChange(of: dateTask.id) { newValue in
                  Task {
                     calendarViewModel.mapID = ""
                     calendarViewModel.mapDataList = []
                                        
                       calendarViewModel.mapID = newValue
                       await calendarViewModel.fetchMap()    
                        }
                     }

// 3. id값은 fetchMap()후에, 배열은 id값이 변화할때 초기화해주니 정상적으로 데이터가 나오게됨
.onAppear {
       Task {
               calendarViewModel.mapID = dateTask.id
                await calendarViewModel.fetchMap()
                 calendarViewModel.mapID = ""
                    }
               }
 .onChange(of: dateTask.id) { newValue in
                  Task {
                     calendarViewModel.mapDataList = []
                                        
                       calendarViewModel.mapID = newValue
                       await calendarViewModel.fetchMap()    
                        }
                     }
```

- 달력의 세부뷰는 기존에 있던 맵뷰모델 들을 불러와서 보여줬었는데 맵뷰의 경우 한번 불러온 내용으로 전체를 보여주기때문에 크게 문제가 없었으나, 달력은 누를때마다 새로운 값을 가져와야했습니다. 그래서 새로운 달력뷰모델을 만들어서 그 안에 Published로 변수를 선언해 id값을 가져오도록 했는데, 초기화 되지 않는 현상을 확인했습니다. 그래서 보여줄 뷰의 내용을 담는 배열도 Published로 선언했고 그 후에 둘을 초기화 해주려고 했는데 초기화 해주는 위치가 맞질 않아서 한칸 다음에 실행되는 결과가 만들어졌습니다. onAppear 상황에서 배열을 초기화하면 내용이 보여지지 않았기 때문에 여기서는 id값만 초기화해주고 onChange될때 배열을 초기화해줘서 새로운 id값으로 받은 배열을 새롭게 담아주게 되니 값이 정상적으로 보이게 되었습니다.

### 특이사항
- 함께한 사람, 꽃갈피 제목을 보여줄지에 대해 논의 필요