### PR TITLE
Fix/#55

### DIFF
--- a/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
+++ b/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		161510C32950305A00BA7FFE /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 161510C22950305A00BA7FFE /* FirebaseAuth */; };
 		161510C52950305A00BA7FFE /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 161510C42950305A00BA7FFE /* FirebaseFirestore */; };
 		161510C7295036B300BA7FFE /* RegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161510C6295036B300BA7FFE /* RegisterModel.swift */; };
+		163247A029C1F78B00DD8FDD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1632479F29C1F78B00DD8FDD /* GoogleService-Info.plist */; };
 		1642F0FA29388BC6005A54EF /* NotoSerifKR-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1642F0F329388BC4005A54EF /* NotoSerifKR-Regular.otf */; };
 		1642F0FB29388BC6005A54EF /* NotoSerifKR-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1642F0F429388BC5005A54EF /* NotoSerifKR-Light.otf */; };
 		1642F0FC29388BC6005A54EF /* NotoSerifKR-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1642F0F529388BC5005A54EF /* NotoSerifKR-SemiBold.otf */; };
@@ -26,7 +27,6 @@
 		16A60C1829B044DC00116569 /* FriendSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1729B044DC00116569 /* FriendSettingView.swift */; };
 		16A60C1A29B0463400116569 /* FriendRequestCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1929B0463400116569 /* FriendRequestCheckView.swift */; };
 		16A60C1C29B04AFF00116569 /* FriendViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1B29B04AFF00116569 /* FriendViewModel.swift */; };
-		16AA0B8629C1E52C002FB416 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 16AA0B8529C1E52B002FB416 /* GoogleService-Info.plist */; };
 		16CA72952939BDE200D451F0 /* AppIcon.appiconset in Resources */ = {isa = PBXBuildFile; fileRef = 16CA72942939BDE200D451F0 /* AppIcon.appiconset */; };
 		16CFFE0629363BEA00DC0B55 /* CalendarSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CFFE0529363BE900DC0B55 /* CalendarSelectView.swift */; };
 		16CFFE0829363CEF00DC0B55 /* InviteFriendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CFFE0729363CEF00DC0B55 /* InviteFriendView.swift */; };
@@ -109,6 +109,7 @@
 /* Begin PBXFileReference section */
 		161510BD29502BE600BA7FFE /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		161510C6295036B300BA7FFE /* RegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterModel.swift; sourceTree = "<group>"; };
+		1632479F29C1F78B00DD8FDD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		1642F0F329388BC4005A54EF /* NotoSerifKR-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSerifKR-Regular.otf"; sourceTree = "<group>"; };
 		1642F0F429388BC5005A54EF /* NotoSerifKR-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSerifKR-Light.otf"; sourceTree = "<group>"; };
 		1642F0F529388BC5005A54EF /* NotoSerifKR-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSerifKR-SemiBold.otf"; sourceTree = "<group>"; };
@@ -123,7 +124,6 @@
 		16A60C1729B044DC00116569 /* FriendSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSettingView.swift; sourceTree = "<group>"; };
 		16A60C1929B0463400116569 /* FriendRequestCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequestCheckView.swift; sourceTree = "<group>"; };
 		16A60C1B29B04AFF00116569 /* FriendViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendViewModel.swift; sourceTree = "<group>"; };
-		16AA0B8529C1E52B002FB416 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		16CA72942939BDE200D451F0 /* AppIcon.appiconset */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.appiconset; sourceTree = "<group>"; };
 		16CFFE0529363BE900DC0B55 /* CalendarSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSelectView.swift; sourceTree = "<group>"; };
 		16CFFE0729363CEF00DC0B55 /* InviteFriendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteFriendView.swift; sourceTree = "<group>"; };
@@ -223,7 +223,7 @@
 		161510BC29502BD100BA7FFE /* NewGilgaon */ = {
 			isa = PBXGroup;
 			children = (
-				16AA0B8529C1E52B002FB416 /* GoogleService-Info.plist */,
+				1632479F29C1F78B00DD8FDD /* GoogleService-Info.plist */,
 				161510BD29502BE600BA7FFE /* RegisterView.swift */,
 				161510C6295036B300BA7FFE /* RegisterModel.swift */,
 				C0C44ACA2950AAA8006FE8A4 /* PleaseLoginView.swift */,
@@ -508,7 +508,7 @@
 			files = (
 				635AE38C2935E934008A8452 /* Preview Assets.xcassets in Resources */,
 				1642F0FD29388BC6005A54EF /* NotoSerifKR-Medium.otf in Resources */,
-				16AA0B8629C1E52C002FB416 /* GoogleService-Info.plist in Resources */,
+				163247A029C1F78B00DD8FDD /* GoogleService-Info.plist in Resources */,
 				1642F0FC29388BC6005A54EF /* NotoSerifKR-SemiBold.otf in Resources */,
 				1642F0FF29388BC6005A54EF /* NotoSerifKR-Bold.otf in Resources */,
 				16CA72952939BDE200D451F0 /* AppIcon.appiconset in Resources */,

--- a/길가온/Gilgaon/Gilgaon/GilgaonApp.swift
+++ b/길가온/Gilgaon/Gilgaon/GilgaonApp.swift
@@ -29,7 +29,7 @@ struct GilgaonApp: App {
         WindowGroup {
             SplashView()
                 .environmentObject(RegisterModel())
-                .environmentObject(LocationsViewModel())
+//                .environmentObject(LocationsViewModel())
                 .environmentObject(SearchViewModel())
 //                .environmentObject(CalendarViewModel())
                 .environmentObject(FireStoreViewModel())

--- a/길가온/Gilgaon/Gilgaon/MapVIew/FlowerMapPreviewView.swift
+++ b/길가온/Gilgaon/Gilgaon/MapVIew/FlowerMapPreviewView.swift
@@ -21,8 +21,8 @@ struct FlowerMapPreview: View {
             VStack(spacing:8){
                 detailButton.sheet(isPresented: $isTapped) {
                     
-                    SheetView()
-                        .presentationDetents([.height(450)])
+//                    SheetView()
+//                        .presentationDetents([.height(450)])
                 }
                 
                 nextButton

--- a/길가온/Gilgaon/Gilgaon/MapVIew/LocationsViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/MapVIew/LocationsViewModel.swift
@@ -8,70 +8,71 @@
 import Foundation
 import MapKit
 import SwiftUI
+import Combine
 
 
-class LocationsViewModel: ObservableObject{
-    @Published var locations: [MarkerModel]
-    
-    @Published var mapLocation: MarkerModel{
-        didSet{
-            updateMapRegion(location: mapLocation)
-        }
-    }
-    
-    @Published var mapRegion: MKCoordinateRegion = MKCoordinateRegion()
-    let mapSpan = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
-    
-    @Published var showLocationsList: Bool = false
-    
-    init(){
-        let locations = LocationsDataService.locations
-        print(locations.count)
-        self.locations = locations
-        self.mapLocation = locations.first!
-        self.updateMapRegion(location: locations.first!)
-    }
-    
-    func doSomeThing() {
-        let locations = LocationsDataService.locations
-        print(locations.count)
-        self.locations = locations
-        self.mapLocation = locations.first!
-        self.updateMapRegion(location: locations.first!)
-    }
-    
-    
-    private func updateMapRegion(location: MarkerModel){
-        withAnimation(.easeInOut){
-            mapRegion = MKCoordinateRegion(center: location.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta:0.02))
-        }
-        
-    }
-    
-    func toggleLocationsList(){
-        withAnimation(.easeInOut) {
-            showLocationsList.toggle()
-        }
-    }
-    
-    func showNextLocation(location: MarkerModel){
-        withAnimation(.easeInOut) {
-            mapLocation = location
-            showLocationsList = false
-        }
-    }
-    
-    func nextButtonPressed(){
-        guard let currentIndex  = locations.firstIndex(where: { $0  == mapLocation }) else { return }
-        
-        let nextIndex = currentIndex + 1
-        guard locations.indices.contains(nextIndex) else{
-            guard let firstLocation = locations.first else {return }
-            showNextLocation(location: firstLocation)
-            return
-        }
-        
-        let nextLocation = locations[nextIndex]
-        showNextLocation(location: nextLocation)
-    }
-}
+//class LocationsViewModel: ObservableObject{
+//    @Published var locations: [MarkerModel]
+//    
+//    @Published var mapLocation: MarkerModel{
+//        didSet{
+//            updateMapRegion(location: mapLocation)
+//        }
+//    }
+//    
+//    @Published var mapRegion: MKCoordinateRegion = MKCoordinateRegion()
+//    let mapSpan = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+//    
+//    @Published var showLocationsList: Bool = false
+//    
+//    init(){
+//        let locations = LocationsDataService.locations
+//        print(locations.count)
+//        self.locations = locations
+//        self.mapLocation = locations.first!
+//        self.updateMapRegion(location: locations.first!)
+//    }
+//    
+//    func doSomeThing() {
+//        let locations = LocationsDataService.locations
+//        print(locations.count)
+//        self.locations = locations
+//        self.mapLocation = locations.first!
+//        self.updateMapRegion(location: locations.first!)
+//    }
+//    
+//    
+//    private func updateMapRegion(location: MarkerModel){
+//        withAnimation(.easeInOut){
+//            mapRegion = MKCoordinateRegion(center: location.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta:0.02))
+//        }
+//        
+//    }
+//    
+//    func toggleLocationsList(){
+//        withAnimation(.easeInOut) {
+//            showLocationsList.toggle()
+//        }
+//    }
+//    
+//    func showNextLocation(location: MarkerModel){
+//        withAnimation(.easeInOut) {
+//            mapLocation = location
+//            showLocationsList = false
+//        }
+//    }
+//    
+//    func nextButtonPressed(){
+//        guard let currentIndex  = locations.firstIndex(where: { $0  == mapLocation }) else { return }
+//        
+//        let nextIndex = currentIndex + 1
+//        guard locations.indices.contains(nextIndex) else{
+//            guard let firstLocation = locations.first else {return }
+//            showNextLocation(location: firstLocation)
+//            return
+//        }
+//        
+//        let nextLocation = locations[nextIndex]
+//        showNextLocation(location: nextLocation)
+//    }
+//}

--- a/길가온/Gilgaon/Gilgaon/MapVIew/SheetView.swift
+++ b/길가온/Gilgaon/Gilgaon/MapVIew/SheetView.swift
@@ -7,127 +7,127 @@
 
 import SwiftUI
 
-struct SheetView: View {
-    @EnvironmentObject var location: LocationsViewModel
-    var body: some View {
-        ZStack {
-            Color(.white)
-                .opacity(0.6)
-                .ignoresSafeArea()
-            
-            //[Title - PlaceName]
-            VStack {
-                HStack{
-                    Text("\(location.mapLocation.locationName) ")
-                        .font(.custom("NotoSerifKR-SemiBold", size: 22))
-                        .fontWeight(.heavy)
-                        .foregroundColor(Color("DarkGray"))
-                        .frame(maxWidth: .infinity)
-                        .padding(.leading, 90)
-                    Image(systemName: "eraser")
-                    Image(systemName: "trash")
-                        .padding(.trailing)
-                }
-                .border(Color("Pink"))
-                .padding()
-                
-                
-                HStack(spacing: 35) {
-                    // [Place Image]
-                    Image("b00")
-                        .resizable()
-                        .frame(width: 150, height: 150)
-                        .cornerRadius(15)
-                    
-                    VStack {
-                        // [PersonName Button]
-                        HStack {
-                            personButton("준수")
-                            personButton("주희")
-                            personButton("민호")
-                            personButton("광현")
-                        }
-                        
-                        // [Time]
-                        Text("15:06")
-                            .font(.custom("NotoSerifKR-SemiBold", size: 15))
-                            .foregroundColor(Color("DarkGray"))
-                            .padding(.leading, 100)
-                            .padding(.bottom)
-                        
-                        // [TextBody]
-                        Text("예쁜 카페에서 \n즐거운 시간 보내기 ♥︎")
-                            .font(.custom("NotoSerifKR-SemiBold", size: 17))
-                            .foregroundColor(Color("DarkGray"))
-                    }
-                    
-                }
-                .padding(.bottom,40)
-                //[SubTitle]
-                Text("오늘의 여정")
-                    .font(.custom("NotoSerifKR-SemiBold", size: 22))
-                    .foregroundColor(Color("DarkGray"))
-                
-                //[Place Images]
-                HStack(spacing: 30){
-                    ForEach(location.locations){ city in
-                        if city == location.mapLocation{
-                            VStack{
-                                ZStack(alignment: .center){
-                                    Image("flowerPink")
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: 40, height: 40)
-                                        .offset(y:-10)
-                                }
-                            }
-                        }else{
-                            HStack{
-                                VStack{
-                                    ZStack{
-                                        Image(city.photo)
-                                            .resizable()
-                                            .scaledToFit()
-                                            .opacity(0.7)
-                                            .frame(width: 60)
-                                            .cornerRadius(10)
-                                            .shadow(radius: 2)
-                                    }
-                                    .padding(4)
-                                    .background(Color("Pink"))
-                                    .cornerRadius(10)
-                                    Text(city.locationName)
-                                }
-                            }
-                            
-                        }
-                        
-                    }
-                    
-                }
-            }
-            
-        }
-    }
-}
+//struct SheetView: View {
+////    @EnvironmentObject var location: LocationsViewModel
+//    var body: some View {
+//        ZStack {
+//            Color(.white)
+//                .opacity(0.6)
+//                .ignoresSafeArea()
+//
+//            //[Title - PlaceName]
+//            VStack {
+//                HStack{
+//                    Text("\(location.mapLocation.locationName) ")
+//                        .font(.custom("NotoSerifKR-SemiBold", size: 22))
+//                        .fontWeight(.heavy)
+//                        .foregroundColor(Color("DarkGray"))
+//                        .frame(maxWidth: .infinity)
+//                        .padding(.leading, 90)
+//                    Image(systemName: "eraser")
+//                    Image(systemName: "trash")
+//                        .padding(.trailing)
+//                }
+//                .border(Color("Pink"))
+//                .padding()
+//
+//
+//                HStack(spacing: 35) {
+//                    // [Place Image]
+//                    Image("b00")
+//                        .resizable()
+//                        .frame(width: 150, height: 150)
+//                        .cornerRadius(15)
+//
+//                    VStack {
+//                        // [PersonName Button]
+//                        HStack {
+//                            personButton("준수")
+//                            personButton("주희")
+//                            personButton("민호")
+//                            personButton("광현")
+//                        }
+//
+//                        // [Time]
+//                        Text("15:06")
+//                            .font(.custom("NotoSerifKR-SemiBold", size: 15))
+//                            .foregroundColor(Color("DarkGray"))
+//                            .padding(.leading, 100)
+//                            .padding(.bottom)
+//
+//                        // [TextBody]
+//                        Text("예쁜 카페에서 \n즐거운 시간 보내기 ♥︎")
+//                            .font(.custom("NotoSerifKR-SemiBold", size: 17))
+//                            .foregroundColor(Color("DarkGray"))
+//                    }
+//
+//                }
+//                .padding(.bottom,40)
+//                //[SubTitle]
+//                Text("오늘의 여정")
+//                    .font(.custom("NotoSerifKR-SemiBold", size: 22))
+//                    .foregroundColor(Color("DarkGray"))
+//
+//                //[Place Images]
+//                HStack(spacing: 30){
+//                    ForEach(location.locations){ city in
+//                        if city == location.mapLocation{
+//                            VStack{
+//                                ZStack(alignment: .center){
+//                                    Image("flowerPink")
+//                                        .resizable()
+//                                        .scaledToFit()
+//                                        .frame(width: 40, height: 40)
+//                                        .offset(y:-10)
+//                                }
+//                            }
+//                        }else{
+//                            HStack{
+//                                VStack{
+//                                    ZStack{
+//                                        Image(city.photo)
+//                                            .resizable()
+//                                            .scaledToFit()
+//                                            .opacity(0.7)
+//                                            .frame(width: 60)
+//                                            .cornerRadius(10)
+//                                            .shadow(radius: 2)
+//                                    }
+//                                    .padding(4)
+//                                    .background(Color("Pink"))
+//                                    .cornerRadius(10)
+//                                    Text(city.locationName)
+//                                }
+//                            }
+//
+//                        }
+//
+//                    }
+//
+//                }
+//            }
+//
+//        }
+//    }
+//}
 
-extension SheetView{
-    private func personButton( _ name: String) -> some View{
-        Button {
-            
-        } label: {
-            Text(name)
-                .foregroundColor(Color("DarkGray"))
-                .font(.custom("NotoSerifKR-SemiBold", size: 17))
-                .bold()
-                .cornerRadius(5)
-        }
-    }
-}
-
-struct SheetView_Previews: PreviewProvider {
-    static var previews: some View {
-        SheetView()
-            .environmentObject(LocationsViewModel())
-    }
-}
+//extension SheetView{
+//    private func personButton( _ name: String) -> some View{
+//        Button {
+//            
+//        } label: {
+//            Text(name)
+//                .foregroundColor(Color("DarkGray"))
+//                .font(.custom("NotoSerifKR-SemiBold", size: 17))
+//                .bold()
+//                .cornerRadius(5)
+//        }
+//    }
+//}
+//
+//struct SheetView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SheetView()
+//            .environmentObject(LocationsViewModel())
+//    }
+//}

--- a/길가온/Gilgaon/Gilgaon/Model/LocationFetcher.swift
+++ b/길가온/Gilgaon/Gilgaon/Model/LocationFetcher.swift
@@ -1,6 +1,10 @@
 import CoreLocation
 import SwiftUI
 import MapKit
+import Firebase
+import FirebaseAuth
+import Combine
+
 
 class LocationFetcher: NSObject, CLLocationManagerDelegate,ObservableObject {
     let manager = CLLocationManager()
@@ -13,6 +17,12 @@ class LocationFetcher: NSObject, CLLocationManagerDelegate,ObservableObject {
 //        CLLocationCoordinate2D(latitude: 37.251384139941024, longitude: 127.06349117923736),
     ]
     
+    let testPoint: [[CLLocationCoordinate2D]] = [
+        [CLLocationCoordinate2D(latitude: 37.25062407449622, longitude: 127.0635877387619),CLLocationCoordinate2D(latitude: 37.25111939891473, longitude: 127.0639310615158),CLLocationCoordinate2D(latitude: 37.251384139941024, longitude: 127.06349117923736)],        [CLLocationCoordinate2D(latitude: 36.25062407449622, longitude: 126.0635877387619),CLLocationCoordinate2D(latitude: 36.25111939891473, longitude: 126.0639310615158),CLLocationCoordinate2D(latitude: 36.251384139941024, longitude: 126.06349117923736)]
+    ]
+    
+    var cancellable = Set<AnyCancellable>()
+    let touchCell = CurrentValueSubject<[CLLocationCoordinate2D],Never>([])
 
     override init() {
         super.init()
@@ -80,6 +90,50 @@ class LocationFetcher: NSObject, CLLocationManagerDelegate,ObservableObject {
     }
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         print("error")
+    }
+    
+    
+    func stopLocation(_ scheduleData: MarkerModel) {
+        //1. 위치정보를 끈다.
+        manager.stopUpdatingLocation()
+        //2. 배열을 서버로 전송한다.
+        Firestore.firestore()
+            .collection("User")
+            .document(Auth.auth().currentUser?.uid ?? "")
+            .collection("Calendar")
+            .document(scheduleData.id)
+            .collection("TrafficLine")
+            .document("dongseon")
+            .setData(["myTrafficLine":points])
+    }
+    
+    func getTrafficLine(_ scheduleData: MarkerModel) async{
+        let ref = Firestore
+                        .firestore()
+                        .collection("User")
+                        .document(Auth.auth().currentUser?.uid ?? "")
+                        .collection("Calendar")
+                        .document(scheduleData.id)
+                        .collection("TrafficLine")
+                        .document("dongseon")
+        
+        do {
+            let snapShot = try await ref.getDocument()
+            let docData = snapShot.data()!
+            let data = docData["myTrafficLine"] as? [CLLocationCoordinate2D] ?? []
+            touchCell.send(data)
+        } catch {
+            print("동선데이터를 받아올 수 없음")
+        }
+    }
+    
+    func a() {
+        touchCell
+            .receive(on: DispatchQueue.main)
+//            .assign(to: &sad)
+            .sink { trafficLine in
+                print(trafficLine)
+            }.store(in: &cancellable)
     }
     
 }

--- a/길가온/Gilgaon/Gilgaon/Model/LocationFetcher.swift
+++ b/길가온/Gilgaon/Gilgaon/Model/LocationFetcher.swift
@@ -26,14 +26,31 @@ class LocationFetcher: NSObject, CLLocationManagerDelegate,ObservableObject {
         manager.requestWhenInUseAuthorization()
         Task {
             if CLLocationManager.locationServicesEnabled() {
-                DispatchQueue.main.async {
-                    self.manager.startUpdatingLocation()
+                switch manager.authorizationStatus {
+                case .authorizedAlways, .authorizedWhenInUse:
+                    print("사용자가 위치 사용하겠다고 알림")
+                    DispatchQueue.main.async {
+                        self.manager.startUpdatingLocation()
+                    }
+                case .notDetermined:
+                    //처음 상태는 notDetermined
+                    print("notDetermined")
+                case .restricted:
+                    print("restricted")
+                case .denied:
+                    await MainActor.run {
+                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                    }
                 }
 //                manager.delegate = self
             } else {
                 print("[Fail] 위치 서비스 off 상태 ")
             }
         }
+    }
+    
+    func setup() {
+        
     }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/길가온/Gilgaon/Gilgaon/Model/LocationFetcher.swift
+++ b/길가온/Gilgaon/Gilgaon/Model/LocationFetcher.swift
@@ -26,8 +26,10 @@ class LocationFetcher: NSObject, CLLocationManagerDelegate,ObservableObject {
         manager.requestWhenInUseAuthorization()
         Task {
             if CLLocationManager.locationServicesEnabled() {
-                manager.startUpdatingLocation()
-                manager.delegate = self
+                DispatchQueue.main.async {
+                    self.manager.startUpdatingLocation()
+                }
+//                manager.delegate = self
             } else {
                 print("[Fail] 위치 서비스 off 상태 ")
             }
@@ -45,6 +47,7 @@ class LocationFetcher: NSObject, CLLocationManagerDelegate,ObservableObject {
         
         if let recentLocation = self.recentLocation {
             print(" ##Count:\(points.count)")
+            print("\(recentLocation.latitude)")
             //현재위치의 좌표 (START)
             let startPoint = CLLocationCoordinate2DMake(recentLocation.latitude, recentLocation.longitude)
             points.append(startPoint)

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/PleaseLoginView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PleaseLoginView: View {
     @EnvironmentObject var registerModel: RegisterModel
+    @EnvironmentObject var locationFetcher: LocationFetcher
     var body: some View {
         
         NavigationStack {
@@ -27,7 +28,14 @@ struct PleaseLoginView: View {
                 if registerModel.currentUserProfile != nil {
                     HomeView()
                         .deferredRendering(for: 1.0)
-                } else { LoginView() }
+                } else {
+                    if locationFetcher.recentLocation != nil {
+                        HomeView()
+                    } else {
+                        LoginView()
+                    }
+                    
+                }
             }
             .onChange(of: registerModel.currentUserProfile, perform: { newValue in
                 registerModel.currentUserProfile = newValue

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/RegisterModel.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/RegisterModel.swift
@@ -140,6 +140,7 @@ class RegisterModel: ObservableObject {
     // MARK: - UserProfile 유무 판별함수
     /// 로그인 후, 해당 유저의 프로필이 등록되어있는지 확인하는 함수
     func fetchUserInfo(_ userId: String) async throws -> FireStoreModel? {
+        print(#function)
         guard (Auth.auth().currentUser != nil) else { return nil}
         let ref = Firestore.firestore().collection("User").document(userId)
         let snapshot = try await ref.getDocument()

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/UserMapView.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/UserMapView.swift
@@ -24,8 +24,20 @@ struct UserMapView: UIViewRepresentable {
         mapView.register(MKAnnotationView.self, forAnnotationViewWithReuseIdentifier: "custom")
         setSubscriber(mapView)
         
-        mapView.showsUserLocation = true
-        mapView.setUserTrackingMode(.follow, animated: true)
+        switch locationFetcher.manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            print("사용자가 위치 사용하겠다고 알림")
+            mapView.showsUserLocation = true
+            mapView.setUserTrackingMode(.follow, animated: true)
+        case .notDetermined:
+            //처음 상태는 notDetermined
+            print("notDetermined")
+        case .restricted:
+            print("restricted")
+        case .denied:
+            print("denied")
+
+        }
         
         if CLLocationCoordinate2DIsValid(startCoordinate) {
             let region = MKCoordinateRegion(center: startCoordinate, latitudinalMeters: 1000, longitudinalMeters: 1000)
@@ -33,14 +45,19 @@ struct UserMapView: UIViewRepresentable {
         }
 
         
-        locationFetcher.$points.sink { _ in
-        } receiveValue: { data in
-            let dt = MKPolyline(coordinates: data, count: data.count)
-            print(data)
-            mapView.addOverlay(dt)
-            mapView.setRegion(MKCoordinateRegion(dt.boundingMapRect), animated: true)
-
-        }
+//        locationFetcher.$points.sink { _ in
+//        } receiveValue: { data in
+//            let dt = MKPolyline(coordinates: data, count: data.count)
+//            print(data)
+//            mapView.addOverlay(dt)
+//            mapView.setRegion(MKCoordinateRegion(dt.boundingMapRect), animated: true)
+//        }
+        
+        let data = locationFetcher.testPoint.randomElement()!
+        print("\(data)")
+        let dt = MKPolyline(coordinates: data, count: data.count)
+        mapView.addOverlay(dt)
+        mapView.setRegion(MKCoordinateRegion(dt.boundingMapRect), animated: true)
 
         
         return mapView

--- a/길가온/Gilgaon/Gilgaon/View/HomeView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/HomeView.swift
@@ -23,6 +23,9 @@ struct HomeView: View {
             TabBarView(selectedTabBar: $selectedTabBar)
                 .frame(height: 30)
         }
+        .onAppear {
+            print("==  HomeView  ==")
+        }
         .navigationBarBackButtonHidden(true)
         .accentColor(Color("Red"))
         .fullScreenCover(isPresented: $isFirstLaunching) {

--- a/길가온/Gilgaon/Gilgaon/View/OnBoard/OnboardingTabView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/OnBoard/OnboardingTabView.swift
@@ -56,9 +56,9 @@ struct OnboardingTabView: View {
             VStack {
                 Spacer()
                 Button {
-                    Task {
-                        await self.locationFetcher.setLocationManager()
-                    }
+//                    Task {
+//                        await self.locationFetcher.setLocationManager()
+//                    }
 //                    sleep(3)
                     isFirstLaunching = false
                 } label: {

--- a/길가온/Gilgaon/Gilgaon/View/SplashView/SplashView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/SplashView/SplashView.swift
@@ -60,6 +60,7 @@ struct SplashView: View {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                     self.isActive = true
                 }
+                print("Splash")
             }
         }
     }

--- a/길가온/Gilgaon/Gilgaon/View/TestAPIView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/TestAPIView.swift
@@ -13,7 +13,7 @@ struct TestAPIView: View {
     var searchNetwork: SearchNetwork = SearchNetwork()
     @EnvironmentObject var viewModel: SearchViewModel
     @ObservedObject var jogakData: JogakData = JogakData()
-    @EnvironmentObject private var vm: LocationsViewModel
+//    @EnvironmentObject private var vm: LocationsViewModel
     @State private var searchText: String = ""
     @Binding var lonString: String
     @Binding var lanString: String
@@ -74,7 +74,7 @@ struct TestAPIView: View {
 //                                    link: "dfsdfsdf"))
 //                            jogakData.datum.append(datum)
                             dismiss()
-                            vm.doSomeThing()
+//                            vm.doSomeThing()
                         } label: {
                             Text("\(datum.name)")
                                 .font(.custom("NotoSerifKR-SemiBold", size: 15))


### PR DESCRIPTION
## 제목

맵의 동선을 그리는 데 앞서 버그를 수정하고 생성 및 불러오는 함수를 구현하였습니다.

### 작업사항
- 위치추적을 받을 시 로그인화면으로 강제이동되는 현상 수정
- 지금까지 그린 동선을 서버로 저장하는 함수 구현
- 서랍의 기록을 클릭 시 동선을 서버로부터 받아오는 함수 구현

```swift
if registerModel.currentUserProfile != nil { HomeView() } 
else { if locationFetcher.recentLocation != nil { HomeView() } else { LoginView() } }
```
>유저의 프로필이 있으면서 현재위치가 있다면 -> 홈화면
그렇지 않다면 유저가 아니고 위치도 받지 않았을 것이므로 -> 로그인으로 이동하게 됩니다.
가독성이 많이 떨어질 수 있어서 위치정보 && 프로필로 한번에 분기처리를 하는 것도 고려해볼 수 있습니다.


```swift
    func setLocationManager() async {
        manager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
        manager.requestWhenInUseAuthorization()
        Task {
            if CLLocationManager.locationServicesEnabled() {
                switch manager.authorizationStatus {
                case .authorizedAlways, .authorizedWhenInUse:
                    print("사용자가 위치 사용하겠다고 알림")
                    DispatchQueue.main.async {
                        self.manager.startUpdatingLocation()
                    }
                case .notDetermined:
                    //처음 상태는 notDetermined
                    print("notDetermined")
                case .restricted:
                    print("restricted")
                case .denied:
                    await MainActor.run {
                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
                    }
                }
            } else {
                print("[Fail] 위치 서비스 off 상태 ")
            }
        }
    }
```
>사용자에 상태에 따른 액션 분류를 초기에는 해두지 않은 상태였습니다. 따라서 이번에 분기처리를 통해 위치정보를 받지 않은 유저에게는 설정창으로 이동하게끔 로직을 수정하였습니다.

### 적용화면
|<img src="https://user-images.githubusercontent.com/66459715/226232009-8d66e9b9-d2a1-4ea4-acf0-340394ae66a4.gif"></img>|<img src="https://user-images.githubusercontent.com/66459715/226232042-878c3caa-6b9d-41cb-bf81-54802f680b40.gif"></img>|
|:-:|:-:|
|`초기 사용자로부터 위치를 시작`|`초기 사용자로부터 위치정보 거절을 눌렀을 때`|

```swift
   //Create 
    func stopLocation(_ scheduleData: MarkerModel) {
        //1. 위치정보를 끈다.
        manager.stopUpdatingLocation()
        //2. 배열을 서버로 전송한다.
        Firestore.firestore()
            .collection("User")
            .document(Auth.auth().currentUser?.uid ?? "")
            .collection("Calendar")
            .document(scheduleData.id)
            .collection("TrafficLine")
            .document("dongseon")
            .setData(["myTrafficLine":points])
    }
    
    //Read
    func getTrafficLine(_ scheduleData: MarkerModel) async{
        let ref = Firestore
                        .firestore()
                        .collection("User")
                        .document(Auth.auth().currentUser?.uid ?? "")
                        .collection("Calendar")
                        .document(scheduleData.id)
                        .collection("TrafficLine")
                        .document("dongseon")
        
        do {
            let snapShot = try await ref.getDocument()
            let docData = snapShot.data()!
            let data = docData["myTrafficLine"] as? [CLLocationCoordinate2D] ?? []
            touchCell.send(data)
        } catch {
            print("동선데이터를 받아올 수 없음")
        }
    }
```
>지금까지 사용자의 동선을 만들고 이를 불러올 수 있는 함수입니다. 현재 맵뷰 연결이 원할하지 않아 MockData를 통해 확인을 완료한 상태이고
```swift
let touchCell = CurrentValueSubject<[CLLocationCoordinate2D],Never>([])

func whenTouchCell() {
    touchCell
            .receive(on: DispatchQueue.main)
            .sink { trafficLine in
                print(trafficLine)
            }.store(in: &cancellable)
}
```
>이처럼 구독을 통해 데이터를 넘겨받는 상황또한 체크하여 이식하기만 하면 되는 상태입니다.


### 특이사항
- Background에서의 작업은 리젝사유가 되지 않게 꼼꼼히 체크할 필요가 있다고 판단하여 맵이 연결된 후 고려 할 예정입니다.