### PR TITLE
Feat/#56

### DIFF
--- a/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
+++ b/길가온/Gilgaon/Gilgaon.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		16A60C1829B044DC00116569 /* FriendSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1729B044DC00116569 /* FriendSettingView.swift */; };
 		16A60C1A29B0463400116569 /* FriendRequestCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1929B0463400116569 /* FriendRequestCheckView.swift */; };
 		16A60C1C29B04AFF00116569 /* FriendViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A60C1B29B04AFF00116569 /* FriendViewModel.swift */; };
-		16AA0B8629C1E52C002FB416 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 16AA0B8529C1E52B002FB416 /* GoogleService-Info.plist */; };
 		16CA72952939BDE200D451F0 /* AppIcon.appiconset in Resources */ = {isa = PBXBuildFile; fileRef = 16CA72942939BDE200D451F0 /* AppIcon.appiconset */; };
 		16CFFE0629363BEA00DC0B55 /* CalendarSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CFFE0529363BE900DC0B55 /* CalendarSelectView.swift */; };
 		16CFFE0829363CEF00DC0B55 /* InviteFriendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CFFE0729363CEF00DC0B55 /* InviteFriendView.swift */; };
@@ -72,6 +71,7 @@
 		634BC642295039D10044B38B /* DrawerScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634BC641295039D10044B38B /* DrawerScheduleView.swift */; };
 		634BC64429503C000044B38B /* DrawerSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634BC64329503C000044B38B /* DrawerSettingView.swift */; };
 		634BC646295043110044B38B /* FriendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634BC645295043110044B38B /* FriendsView.swift */; };
+		6352D9B729C5498E00928BAE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6352D9B629C5498E00928BAE /* GoogleService-Info.plist */; };
 		635AE3852935E932008A8452 /* GilgaonApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635AE3842935E932008A8452 /* GilgaonApp.swift */; };
 		635AE3892935E934008A8452 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 635AE3882935E934008A8452 /* Assets.xcassets */; };
 		635AE38C2935E934008A8452 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 635AE38B2935E934008A8452 /* Preview Assets.xcassets */; };
@@ -123,7 +123,6 @@
 		16A60C1729B044DC00116569 /* FriendSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSettingView.swift; sourceTree = "<group>"; };
 		16A60C1929B0463400116569 /* FriendRequestCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendRequestCheckView.swift; sourceTree = "<group>"; };
 		16A60C1B29B04AFF00116569 /* FriendViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendViewModel.swift; sourceTree = "<group>"; };
-		16AA0B8529C1E52B002FB416 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		16CA72942939BDE200D451F0 /* AppIcon.appiconset */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.appiconset; sourceTree = "<group>"; };
 		16CFFE0529363BE900DC0B55 /* CalendarSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSelectView.swift; sourceTree = "<group>"; };
 		16CFFE0729363CEF00DC0B55 /* InviteFriendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteFriendView.swift; sourceTree = "<group>"; };
@@ -166,6 +165,7 @@
 		634BC641295039D10044B38B /* DrawerScheduleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerScheduleView.swift; sourceTree = "<group>"; };
 		634BC64329503C000044B38B /* DrawerSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerSettingView.swift; sourceTree = "<group>"; };
 		634BC645295043110044B38B /* FriendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsView.swift; sourceTree = "<group>"; };
+		6352D9B629C5498E00928BAE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		635AE3812935E932008A8452 /* Gilgaon.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gilgaon.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		635AE3842935E932008A8452 /* GilgaonApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GilgaonApp.swift; sourceTree = "<group>"; };
 		635AE3882935E934008A8452 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -223,7 +223,6 @@
 		161510BC29502BD100BA7FFE /* NewGilgaon */ = {
 			isa = PBXGroup;
 			children = (
-				16AA0B8529C1E52B002FB416 /* GoogleService-Info.plist */,
 				161510BD29502BE600BA7FFE /* RegisterView.swift */,
 				161510C6295036B300BA7FFE /* RegisterModel.swift */,
 				C0C44ACA2950AAA8006FE8A4 /* PleaseLoginView.swift */,
@@ -342,6 +341,7 @@
 				1642F0EC2938897E005A54EF /* Font */,
 				C0FA4348293623F4002D4473 /* Gilgaon.entitlements */,
 				6FF334CA2935F1D9007438B1 /* Info.plist */,
+				6352D9B629C5498E00928BAE /* GoogleService-Info.plist */,
 				635AE3842935E932008A8452 /* GilgaonApp.swift */,
 				3663C66D2938631E006880C9 /* MapVIew */,
 				635AE3A729361971008A8452 /* View */,
@@ -508,7 +508,7 @@
 			files = (
 				635AE38C2935E934008A8452 /* Preview Assets.xcassets in Resources */,
 				1642F0FD29388BC6005A54EF /* NotoSerifKR-Medium.otf in Resources */,
-				16AA0B8629C1E52C002FB416 /* GoogleService-Info.plist in Resources */,
+				6352D9B729C5498E00928BAE /* GoogleService-Info.plist in Resources */,
 				1642F0FC29388BC6005A54EF /* NotoSerifKR-SemiBold.otf in Resources */,
 				1642F0FF29388BC6005A54EF /* NotoSerifKR-Bold.otf in Resources */,
 				16CA72952939BDE200D451F0 /* AppIcon.appiconset in Resources */,

--- a/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreModel.swift
+++ b/길가온/Gilgaon/Gilgaon/NewGilgaon/FireStoreModel.swift
@@ -67,6 +67,17 @@ struct MarkerModel: Identifiable, Equatable, Hashable {
         return dateFormatter.string(from: dateCreatedAt)
     }
     
+    var calendarDate: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_Kr")
+        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
+        dateFormatter.dateFormat = "HH:mm"
+        
+        let dateCreatedAt = Date(timeIntervalSince1970: createdAt)
+        
+        return dateFormatter.string(from: dateCreatedAt)
+    }
+    
     static func == (lhs: MarkerModel, rhs: MarkerModel) -> Bool {
         lhs.id == rhs.id
     }

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -35,17 +35,17 @@ struct CalendarSelectView: View {
                             .foregroundColor(.clear)
                             
                             VStack {
-                                Text(item.createdDate)
+                                Text(item.calendarDate)
                                 Text(item.locationName)
                             }
                             .padding()
+                            .frame(minWidth: 180)
                             .overlay {
                                 RoundedRectangle(cornerRadius: 10)
                                     .stroke(Color("Pink"), lineWidth: 1.5)
                             }
                         }
                     }
-                    .foregroundColor(Color("DarkGray"))
                     .font(.custom("NotoSerifKR-Regular", size: 18))
                 }
                 .padding()

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -11,6 +11,7 @@ struct CalendarSelectView: View {
     
     @ObservedObject var calendarViewModel: CalendarViewModel
     
+    
     var body: some View {
         
         ZStack {
@@ -18,37 +19,86 @@ struct CalendarSelectView: View {
                 .ignoresSafeArea()
             
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack {
-                    ForEach(calendarViewModel.mapDataList, id: \.self) { item in
-                        VStack {
-                            HStack {
-                                Rectangle()
-                                    .frame(height: 1)
-                                
-                               Image("flowerPink")
-                                    .resizable()
-                                    .frame(width: 30, height: 30)
-                                
-                                Rectangle()
-                                    .frame(height: 1)
-                            }
-                            .foregroundColor(.clear)
+                VStack {
+                    ForEach(calendarViewModel.calendarList, id: \.self) { item in
+                        HStack {
+                            Text(item.title)
+                                .font(.custom("NotoSerifKR-Bold", size: 15))
                             
-                            VStack {
-                                Text(item.calendarDate)
-                                Text(item.locationName)
-                            }
-                            .padding()
-                            .frame(minWidth: 180)
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color("Pink"), lineWidth: 1.5)
+                            HStack(spacing: -10) {
+                                ForEach(calendarViewModel.sharedFriend, id: \.self) { user in
+                                    if let url = user.userPhoto,
+                                       let imageUrl = URL(string: url) {
+                                        AsyncImage(url: imageUrl) { image in
+                                            image
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                                .frame(width: 30, height: 30)
+                                                .clipShape(Circle())
+                                                .background(
+                                                    Circle()
+                                                        .stroke(Color("DarkGray"), lineWidth: 2)
+                                                )
+                                        } placeholder: {
+                                            Image(systemName: "person.fill")
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fill)
+                                                .frame(width: 30, height: 30)
+                                                .clipShape(Circle())
+                                                .background(
+                                                    Circle()
+                                                        .stroke(Color("DarkGray"), lineWidth: 2)
+                                                )
+                                        }
+                                    } else{
+                                        Image(systemName: "person.fill")
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fill)
+                                            .frame(width: 30, height: 30)
+                                            .clipShape(Circle())
+                                            .background(
+                                                Circle()
+                                                    .stroke(Color("DarkGray"), lineWidth: 2)
+                                            )
+                                    }
+                                }
                             }
                         }
+                        .padding()
                     }
-                    .font(.custom("NotoSerifKR-Regular", size: 18))
+                    
+                    HStack {
+                        ForEach(calendarViewModel.mapDataList, id: \.self) { item in
+                            VStack {
+                                HStack {
+                                    Rectangle()
+                                        .frame(height: 1)
+                                    
+                                    Image("flowerPink")
+                                        .resizable()
+                                        .frame(width: 30, height: 30)
+                                    
+                                    Rectangle()
+                                        .frame(height: 1)
+                                }
+                                .foregroundColor(.clear)
+                                
+                                VStack {
+                                    Text(item.calendarDate)
+                                    Text(item.locationName)
+                                }
+                                .padding()
+                                .frame(minWidth: 180)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(Color("Pink"), lineWidth: 1.5)
+                                }
+                            }
+                        }
+                        .font(.custom("NotoSerifKR-Regular", size: 18))
+                    }
+                    .padding()
                 }
-                .padding()
             }
         }
     }

--- a/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarSelectView.swift
@@ -25,17 +25,14 @@ struct CalendarSelectView: View {
                                 Rectangle()
                                     .frame(height: 1)
                                 
-                                Circle()
-                                    .frame(width: 15, height: 15)
-                                    .background(
-                                        Circle()
-                                            .stroke(lineWidth: 1)
-                                            .padding(-3)
-                                    )
+                               Image("flowerPink")
+                                    .resizable()
+                                    .frame(width: 30, height: 30)
                                 
                                 Rectangle()
                                     .frame(height: 1)
                             }
+                            .foregroundColor(.clear)
                             
                             VStack {
                                 Text(item.createdDate)

--- a/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
@@ -25,5 +25,8 @@ final class CalendarViewModel: ObservableObject {
     func fetchMap() async {
         self.mapDataList = await fireStore.fetchMarkers(inputID: self.mapID).sorted(by: { $1.createdDate > $0.createdDate})
     }
+    
+    
+    
 }
 

--- a/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CalendarViewModel.swift
@@ -7,26 +7,29 @@
 
 import Foundation
 
+@MainActor
 final class CalendarViewModel: ObservableObject {
     
     let fireStore = FireStoreViewModel()
     
-    @Published var drawerID: String = ""
-    @Published var mapID: String = ""
-    @Published var drawerDataList: [DayCalendarModel] = []
+    @Published var documentID: String = ""
     @Published var mapDataList: [MarkerModel] = []
     
-    func fetchDrawer() {
-        fireStore.fetchDayCalendar()
-        self.drawerDataList = fireStore.calendarList
-    }
+    @Published var calendarList: [DayCalendarModel] = []
+    @Published var sharedFriend: [FriendModel] = []
     
-    @MainActor
+    
     func fetchMap() async {
-        self.mapDataList = await fireStore.fetchMarkers(inputID: self.mapID).sorted(by: { $1.createdDate > $0.createdDate})
+        self.mapDataList = await fireStore.fetchMarkers(inputID: self.documentID).sorted(by: { $1.createdDate > $0.createdDate})
     }
     
+    func fetchCarendar() async {
+        self.calendarList = await fireStore.fetchCarendalData(inputID: self.documentID)
+    }
     
-    
+    func fetchSharedFriendImage() async {
+        let userId = await fireStore.fetchCarendalData(inputID: self.documentID)
+        self.sharedFriend = await fireStore.getImageURL(userId: userId.first?.shareFriend ?? [])
+    }
 }
 

--- a/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
+++ b/길가온/Gilgaon/Gilgaon/View/CustomDataPicker.swift
@@ -12,7 +12,6 @@ struct CustomDataPicker: View {
     @EnvironmentObject var fireStoreModel: FireStoreViewModel
     @ObservedObject var calendarVViewModel: CalendarVViewModel
     @State var currentDate = Date()
-    // @StateObject var fireStoreModel: FireStoreViewModel = FireStoreViewModel()
     @StateObject var calendarViewModel: CalendarViewModel = CalendarViewModel()
 
     @Binding var calID: [String]
@@ -48,13 +47,6 @@ struct CustomDataPicker: View {
                                 }
                                 
                             }
-
-//
-//                            VStack() {
-//                                Text(extraDate()[0])
-//                                    .font(.custom("NotoSerifKR-SemiBold", size: 15))
-//                                    .foregroundColor(Color("DarkGray"))
-//                            }
                             
                             Spacer()
                             
@@ -144,18 +136,23 @@ struct CustomDataPicker: View {
                             CalendarSelectView(calendarViewModel: calendarViewModel)
                                 .onAppear {
                                     Task {
-                                        calendarViewModel.mapID = dateTask.id
+                                        calendarViewModel.documentID = dateTask.id
                                         await calendarViewModel.fetchMap()
-                                        calendarViewModel.mapID = ""
+                                        await calendarViewModel.fetchCarendar()
+                                        await calendarViewModel.fetchSharedFriendImage()
+                                        calendarViewModel.documentID = ""
                                     }
                                 }
                                 .onChange(of: dateTask.id) { newValue in
                                     Task {
                                         calendarViewModel.mapDataList = []
+                                        calendarViewModel.calendarList = []
+                                        calendarViewModel.sharedFriend = []
                                         
-                                        calendarViewModel.mapID = newValue
+                                        calendarViewModel.documentID = newValue
                                         await calendarViewModel.fetchMap()
-                                        
+                                        await calendarViewModel.fetchCarendar()
+                                        await calendarViewModel.fetchSharedFriendImage()
                                     }
                                 }
                         }


### PR DESCRIPTION
## 달력뷰 세부 수정
- 디자인 변경
- 날짜 시간만 나오게 하기
- 꽃갈피 제목, 함께한 친구

### 작업사항
- 달력세부뷰에 디자인 수정 : 마커를 이용해서 다녀온 장소를 표시
- 세부뷰 안에 시간이 날짜 + 시간으로 나와서 시간만 나오게 수정
- 세부뷰 안에 꽃갈피 + 함께한 친구가 나오게해 더 직관적으로 보여주게 바꿈

### 적용화면
<img src="https://user-images.githubusercontent.com/107897929/226273492-143accc8-cd92-4050-8e81-1f146dc0edf9.gif"></img>
처음에 각각마다 id 값을 받아왔는데 똑같은 값을 받아오는거라 documentId로 변수를 수정해서 코드 중복을 피하도록 수정했습니다.
데이터에 제목(title)이 없으면 함께한 친구만 나오게 되는데 앞에 너무 간격이 떨어져있게 되어 어떻게 수정하면 좋을지 피드백 부탁드립니다.
그리고 제목이랑 함께한 친구의 위치도 피드백 부탁드립니다!